### PR TITLE
[DO NOT MERGE] Add TNA multipipe

### DIFF
--- a/p4src/build.sh
+++ b/p4src/build.sh
@@ -42,7 +42,8 @@ function do_p4c() {
   echo "*** Output in ${P4C_OUT}/${pltf}"
   pp_flags="-DCPU_PORT=${cpu_port}"
   p4c_flags="--auto-init-metadata"
-  mkdir -p ${P4C_OUT}/${pltf}
+  rm -rf ${P4C_OUT}/${pltf}
+  mkdir ${P4C_OUT}/${pltf}
   (
     $P4C_CMD --arch tna -g --create-graphs --verbose 2 \
       -o ${P4C_OUT}/${pltf} -I ${P4_SRC_DIR} \
@@ -53,24 +54,21 @@ function do_p4c() {
       ${DIR}/fabric_tna.p4
   )
 
-  # Copy only the relevant files to the pipeconf resources.
-  mkdir -p "${DEST_DIR}/stratum_bf/${pltf}/pipe"
-  cp "${P4C_OUT}/${pltf}/p4info.txt" "${DEST_DIR}/stratum_bf/${pltf}"
-  cp "${P4C_OUT}/${pltf}/bfrt.json" "${DEST_DIR}/stratum_bf/${pltf}"
-  cp "${P4C_OUT}/${pltf}/pipe/context.json" "${DEST_DIR}/stratum_bf/${pltf}/pipe"
-  cp "${P4C_OUT}/${pltf}/pipe/tofino.bin" "${DEST_DIR}/stratum_bf/${pltf}/pipe"
-  echo "${cpu_port}" > "${DEST_DIR}/stratum_bf/${pltf}/cpu_port.txt"
-
   # New pipeline format which uses tar bal
   rm -rf "${DEST_DIR}/stratum_bfrt/${pltf}"
-  mkdir -p "${DEST_DIR}/stratum_bfrt/${pltf}"
+  mkdir "${DEST_DIR}/stratum_bfrt/${pltf}"
   tar cf "pipeline.tar.bz2" -C "${P4C_OUT}/${pltf}" .
   mv "pipeline.tar.bz2" "${DEST_DIR}/stratum_bfrt/${pltf}/"
+  # FIXME: instrument tm entrypoint to untar pipeline.tar.bz2
+  #  Instead of copying the same content next to it
   cp "${P4C_OUT}/${pltf}/p4info.txt" "${DEST_DIR}/stratum_bfrt/${pltf}/"
   cp "${P4C_OUT}/${pltf}/bfrt.json" "${DEST_DIR}/stratum_bfrt/${pltf}/"
-  cp -r "${P4C_OUT}/${pltf}/pipeline_profile_a" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_a"
-  cp -r "${P4C_OUT}/${pltf}/pipeline_profile_b" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_b"
-  cp -r "${P4C_OUT}/${pltf}/pipe" "${DEST_DIR}/stratum_bfrt/${pltf}/pipe"
+  mkdir "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_a"
+  mkdir "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_b"
+  cp "${P4C_OUT}/${pltf}/pipeline_profile_a/context.json" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_a/"
+  cp "${P4C_OUT}/${pltf}/pipeline_profile_a/tofino.bin" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_a/"
+  cp "${P4C_OUT}/${pltf}/pipeline_profile_b/context.json" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_b/"
+  cp "${P4C_OUT}/${pltf}/pipeline_profile_b/tofino.bin" "${DEST_DIR}/stratum_bfrt/${pltf}/pipeline_profile_b/"
   echo "${cpu_port}" > "${DEST_DIR}/stratum_bfrt/${pltf}/cpu_port.txt"
 }
 

--- a/p4src/fabric_tna.p4
+++ b/p4src/fabric_tna.p4
@@ -94,7 +94,7 @@ control FabricIngressB(
         if (ig_tm_md.bypass_egress == 1w0) {
             hdr.bridge_md.setValid();
             hdr.bridge_md.is_multicast = fabric_md.is_multicast;
-            hdr.bridge_md.ingress_port = ig_intr_md.ingress_port;
+            hdr.bridge_md.ingress_port = fabric_md.ingress_port;
             hdr.bridge_md.ip_eth_type = fabric_md.ip_eth_type;
             hdr.bridge_md.ip_proto = fabric_md.ip_proto;
             hdr.bridge_md.mpls_label = fabric_md.mpls_label;
@@ -137,24 +137,29 @@ control FabricEgress (
 // Packet comes into ingress profile_a. The packet travels to egress profile_b, then to
 // ingress profile_b and finally to egress profile_a.
 
-// Packet flow: ingress_a, egress_b, ingress_b, egress_a
+// Packet flow: -> ingress_a --TM--> egress_b --+ (loopback)
+//              <- egress_a <--TM-- ingress_b <-+
 
 // For tofino model:
 // --int-port-loop=<pipe_bitmap> (0xA)
 
 Pipeline(
+    // ingress_a
     FabricIngressParser(),
     FabricIngress(),
     FabricIngressDeparser(),
+    // egress_a
     FabricEgressParser(),
     FabricEgress(),
     FabricEgressDeparser()
 ) pipeline_profile_a;
 
 Pipeline(
+    // ingress_b
     FabricIngressParserB(),
     FabricIngressB(),
     FabricIngressDeparser(),
+    // egress_b (empty)
     FabricEgressParserB(),
     FabricEgressB(),
     FabricEgressDeparserB()

--- a/p4src/include/header.p4
+++ b/p4src/include/header.p4
@@ -111,6 +111,7 @@ header icmp_t {
 @flexible
 @pa_auto_init_metadata
 struct fabric_ingress_metadata_t {
+    PortId_t        ingress_port; // Original ingress port from ingress_a
     vlan_id_t       vlan_id;
     bit<3>          vlan_pri;
     bit<1>          vlan_cfi;

--- a/p4src/include/parser.p4
+++ b/p4src/include/parser.p4
@@ -213,6 +213,7 @@ parser FabricIngressParserB(packet_in  packet,
         fabric_md.fwd_type = bridge_md.fwd_type;
         fabric_md.vlan_id = bridge_md.vlan_id;
         fabric_md.is_multicast = bridge_md.is_multicast;
+        fabric_md.ingress_port = bridge_md.ingress_port;
         transition parse_ethernet;
     }
 


### PR DESCRIPTION
<details><summary>PTF log</summary>
<p>


```
> ./ptf/run/tm/run fabric
*** Testing profile 'fabric'...
*** Detected BF SDE version 9.2.0 (tofino-model), required 9.2.0...
*** Using P4 compiler output in /Users/max/projects/fabric-tna/ptf/run/tm/../../../src/main/resources/p4c-out/fabric/stratum_bfrt/mavericks_sde_9_2_0...
*** Starting tofino-model-9960 (from opennetworking/bf-sde:9.2.0-bfrt)...
bd86e68ed24be4c7ad24910119307c069c2705aced2c71022aa8580a445d265a
*** Starting stratum-bf-9960 (from stratumproject/stratum-bfrt:9.2.0)...
4ead2e6c7cab2d27d69cf42dd538a986788cf9cec3cfc74f6061e8d729c10ce7
*** Wait for stratum-bf-9960 to start up (port 28000)...
wait-for-it.sh: waiting 190 seconds for localhost:28000
wait-for-it.sh: localhost:28000 is available after 53 seconds
*** Starting fabric-p4test-9960...
************************************************
STARTING PTF TESTS...
************************************************
python -u ptf_runner.py --device stratum-bfrt --port-map port_map.veth.json --ptf-dir fabric.ptf --cpu-port 320 --device-id 1 --grpc-addr "127.0.0.1:28000" --p4info /p4c-out/p4info.txt --tofino-pipeline-tar /p4c-out/pipeline.tar.bz2 all ^spgw ^int ^bng ^dth ^xconnect
INFO:PTF runner:Sending P4 config
INFO:PTF runner:Executing PTF command: ptf --test-dir fabric.ptf -i 0@veth1 -i 1@veth3 -i 2@veth5 -i 3@veth7 -i 4@veth9 -i 5@veth11 -i 6@veth13 -i 7@veth15 --test-params=p4info='/p4c-out/p4info.txt';grpcaddr='127.0.0.1:28000';device_id='1';cpu_port='320';device='stratum-bfrt' all ^spgw ^int ^bng ^dth ^xconnect
WARNING: No route found for IPv6 destination :: (no default route?)
test.FabricIPv4MplsGroupTest ...
Testing tcp packet with tagged=True...
Testing udp packet with tagged=True...
Testing icmp packet with tagged=True...
Testing tcp packet with tagged=False...
Testing udp packet with tagged=False...
Testing icmp packet with tagged=False...
ok

----------------------------------------------------------------------
Ran 1 test in 1.940s

OK
test.FabricIPv4UnicastGroupTestAllPortTcpSport ... ok

----------------------------------------------------------------------
Ran 1 test in 13.826s

OK
test.FabricIPv4UnicastGroupTestAllPortIpSrc ... ok

----------------------------------------------------------------------
Ran 1 test in 27.219s

OK
test.FabricLongIpPacketOutTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.257s

OK
test.FabricArpPacketInTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.390s

OK
test.FabricBridgingTest ...
Testing tcp packet with VLAN untag->tag..
Testing udp packet with VLAN untag->tag..
Testing icmp packet with VLAN untag->tag..
Testing tcp packet with VLAN tag->tag..
Testing udp packet with VLAN tag->tag..
Testing icmp packet with VLAN tag->tag..
Testing tcp packet with VLAN untag->untag..
Testing udp packet with VLAN untag->untag..
Testing icmp packet with VLAN untag->untag..
Testing tcp packet with VLAN tag->untag..
Testing udp packet with VLAN tag->untag..
Testing icmp packet with VLAN tag->untag..
ok

----------------------------------------------------------------------
Ran 1 test in 4.234s

OK
test.MulticastGroupModificationTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.052s

OK
test.TableEntryReadWriteTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.041s

OK
test.FabricMplsSegmentRoutingTest ...
Testing tcp packet, next_hop_spine=True...
Testing tcp packet, next_hop_spine=False...
Testing udp packet, next_hop_spine=True...
Testing udp packet, next_hop_spine=False...
Testing icmp packet, next_hop_spine=True...
Testing icmp packet, next_hop_spine=False...
ok

----------------------------------------------------------------------
Ran 1 test in 0.992s

OK
test.FabricArpBroadcastMixedTest ... FAIL

======================================================================
FAIL: test.FabricArpBroadcastMixedTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/fabric-p4test/tests/ptf/base_test.py", line 790, in handle
    return f(*args, **kwargs)
  File "fabric.ptf/test.py", line 77, in runTest
    untagged_ports=[self.port1])
  File "/fabric-p4test/tests/ptf/fabric_test.py", line 731, in runArpBroadcastTest
    testutils.verify_no_other_packets(self)
  File "/usr/local/lib/python2.7/dist-packages/ptf/testutils.py", line 2579, in verify_no_other_packets
    "packets.\n%s" % (result.device, result.port, result.format()))
AssertionError: A packet was received on device 0, port 1, but we expected no packets.
========== RECEIVED ==========
0000   FF FF FF FF FF FF 00 06  07 08 09 0A 08 06 00 01   ................
0010   08 00 06 04 00 01 00 06  07 08 09 0A C0 A8 00 01   ................
0020   00 00 00 00 00 00 C0 A8  00 02 00 00 00 00 00 00   ................
0030   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................
0040   00 00 00 00 00 00 00 00  00 00 00 00               ............
==============================


----------------------------------------------------------------------
Ran 1 test in 0.647s

FAILED (failures=1)
test.FabricShortIpPacketOutTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.217s

OK
test.FabricArpBroadcastTaggedTest ... FAIL

======================================================================
FAIL: test.FabricArpBroadcastTaggedTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/fabric-p4test/tests/ptf/base_test.py", line 790, in handle
    return f(*args, **kwargs)
  File "fabric.ptf/test.py", line 68, in runTest
    untagged_ports=[])
  File "/fabric-p4test/tests/ptf/fabric_test.py", line 731, in runArpBroadcastTest
    testutils.verify_no_other_packets(self)
  File "/usr/local/lib/python2.7/dist-packages/ptf/testutils.py", line 2579, in verify_no_other_packets
    "packets.\n%s" % (result.device, result.port, result.format()))
AssertionError: A packet was received on device 0, port 1, but we expected no packets.
========== RECEIVED ==========
0000   FF FF FF FF FF FF 00 06  07 08 09 0A 81 00 00 0A   ................
0010   08 06 00 01 08 00 06 04  00 01 00 06 07 08 09 0A   ................
0020   C0 A8 00 01 00 00 00 00  00 00 C0 A8 00 02 00 00   ................
0030   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................
0040   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................
==============================


----------------------------------------------------------------------
Ran 1 test in 0.695s

FAILED (failures=1)
test.ActionProfileGroupReadWriteTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.038s

OK
test.FabricIPv4UnicastGroupTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.298s

OK
test.ActionProfileMemberReadWriteTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.032s

OK
test.FabricDefaultVlanPacketInTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.281s

OK
test.MulticastGroupReadWriteTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.047s

OK
test.FabricShortIpPacketInTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.297s

OK
test.FabricLongIpPacketInTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.372s

OK
test.FabricIPv4UnicastGroupTestAllPortTcpDport ... ok

----------------------------------------------------------------------
Ran 1 test in 13.428s

OK
test.FabricIPv4UnicastGtpTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.401s

OK
test.FabricTaggedPacketInTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.400s

OK
test.FabricArpPacketOutTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.266s

OK
test.FabricIPv4UnicastGroupTestAllPortIpDst ... ok

----------------------------------------------------------------------
Ran 1 test in 25.956s

OK
test.ActionProfileGroupModificationTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.045s

OK
test.FabricArpBroadcastUntaggedTest ... FAIL

======================================================================
FAIL: test.FabricArpBroadcastUntaggedTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/fabric-p4test/tests/ptf/base_test.py", line 790, in handle
    return f(*args, **kwargs)
  File "fabric.ptf/test.py", line 59, in runTest
    untagged_ports=[self.port1, self.port2, self.port3])
  File "/fabric-p4test/tests/ptf/fabric_test.py", line 731, in runArpBroadcastTest
    testutils.verify_no_other_packets(self)
  File "/usr/local/lib/python2.7/dist-packages/ptf/testutils.py", line 2579, in verify_no_other_packets
    "packets.\n%s" % (result.device, result.port, result.format()))
AssertionError: A packet was received on device 0, port 1, but we expected no packets.
========== RECEIVED ==========
0000   FF FF FF FF FF FF 00 06  07 08 09 0A 08 06 00 01   ................
0010   08 00 06 04 00 01 00 06  07 08 09 0A C0 A8 00 01   ................
0020   00 00 00 00 00 00 C0 A8  00 02 00 00 00 00 00 00   ................
0030   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................
0040   00 00 00 00 00 00 00 00  00 00 00 00               ............
==============================


----------------------------------------------------------------------
Ran 1 test in 0.574s

FAILED (failures=1)
test.FabricIPv4MPLSTest ... ok

----------------------------------------------------------------------
Ran 1 test in 0.881s

OK
test.FabricIPv4UnicastTest ...
Testing tcp packet with VLAN untag->tag...
Testing udp packet with VLAN untag->tag...
Testing icmp packet with VLAN untag->tag...
Testing tcp packet with VLAN tag->tag...
Testing udp packet with VLAN tag->tag...
Testing icmp packet with VLAN tag->tag...
Testing tcp packet with VLAN untag->untag...
Testing udp packet with VLAN untag->untag...
Testing icmp packet with VLAN untag->untag...
Testing tcp packet with VLAN tag->untag...
Testing udp packet with VLAN tag->untag...
Testing icmp packet with VLAN tag->untag...
ok

----------------------------------------------------------------------
Ran 1 test in 3.521s

OK
()
******************************************
ATTENTION: SOME TESTS DID NOT PASS!!!
()
The following tests failed:
FabricArpBroadcastMixedTest, FabricArpBroadcastTaggedTest, FabricArpBroadcastUntaggedTest
()
******************************************
../../tests/ptf/Makefile.profiles:10: recipe for target 'fabric' failed
make: *** [fabric] Error 3
************************************************
SOME PTF TESTS FAILED :(
************************************************
*** Stopping stratum-bf-9960...
*** Stopping tofino-model-9960...
```

</p>
</details>
