### PR TITLE
Increase Stratum log level to INFO

### DIFF
--- a/ptf/run/tm/stratum_entrypoint.sh
+++ b/ptf/run/tm/stratum_entrypoint.sh
@@ -25,6 +25,8 @@ cd /tmp/workdir
     -grpc_max_recv_msg_size=256 \
     -log_dir=./ \
     -logtostderr=true \
+    -stderrthreshold=0 \
+    -v=0 \
     -persistent_config_dir=/tmp \
     -write_req_log_file=./p4rt-write-reqs.log \
     > ./stratum_bf.log 2>&1


### PR DESCRIPTION
Logs will then cantain useful information, if a test fails.

The performance overhead is none, since we copy the log file at the end.