### PR TITLE
Add Acl read test

### DIFF
--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -919,8 +919,7 @@ class TableEntryReadWriteTest(FabricTest):
 
         req, _ = self.add_forwarding_acl_punt_to_cpu(ETH_TYPE_IPV4)
         expected_acl_entry = req.updates[0].entity.table_entry
-        mk = [self.Ternary("eth_type", expected_acl_entry.match[0].ternary.value, expected_acl_entry.match[0].ternary.mask)]
-        received_acl_entry = self.read_table_entry("acl.acl", mk, expected_acl_entry.priority)
+        received_acl_entry = self.read_forwarding_acl_punt_to_cpu(ETH_TYPE_IPV4)
         self.verify_p4runtime_entity(expected_acl_entry, received_acl_entry)
 
     def runTest(self):

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -377,14 +377,19 @@ class FabricTest(P4RuntimeTest):
             [self.Exact("mpls_label", label_)],
             "forwarding.pop_mpls_and_next", [("next_id", next_id_)])
 
-    def add_forwarding_acl_punt_to_cpu(self, eth_type=None):
+    def add_forwarding_acl_punt_to_cpu(self, eth_type=None, priority=DEFAULT_PRIORITY):
         eth_type_ = stringify(eth_type, 2)
-        eth_type_mask = stringify(0xFFFF, 2)
+        eth_type_mask_ = stringify(0xFFFF, 2)
         return self.send_request_add_entry_to_action(
             "acl.acl",
-            [self.Ternary("eth_type", eth_type_, eth_type_mask)],
-            "acl.punt_to_cpu", [],
-            DEFAULT_PRIORITY)
+            [self.Ternary("eth_type", eth_type_, eth_type_mask_)],
+            "acl.punt_to_cpu", [], priority)
+
+    def read_forwarding_acl_punt_to_cpu(self, eth_type=None, priority=DEFAULT_PRIORITY):
+        eth_type_ = stringify(eth_type, 2)
+        eth_type_mask_ = stringify(0xFFFF, 2)
+        mk = [self.Ternary("eth_type", eth_type_, eth_type_mask_)]
+        return self.read_table_entry("acl.acl", mk, priority)
 
     def add_forwarding_acl_copy_to_cpu(self, eth_type=None):
         eth_type_ = stringify(eth_type, 2)


### PR DESCRIPTION
This adds an ACL read test to ensure Stratum handles actions without parameters correctly.

<s>It currently fails with</s> Fixed
```
2020-06-30 19:48:52.504283 BF_BFRT ERROR - tableEntryGet:1288 pipe.FabricIngress.acl.acl ERROR : Entry does not exist
E0630 19:48:52.504500    47 bfrt_table_manager.cc:246] StratumErrorSpace::ERR_ENTRY_NOT_FOUND: 'table->tableEntryGet( *bfrt_session, bf_dev_tgt, *table_key, bfrt::BfRtTable::BfRtTableGetFlag::GET_FROM_SW, table_data.get())' failed with error message: Object not found. 
```