### PR TITLE
Allow running tests also on stratum-bf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,6 @@ clean:
 	-rm -rf src/main/resources/p4c-out
 
 deep-clean: clean
+	-rm -rf tmp
 	-rm -rf target
-	-rm -rf src/main/resources/p4c-out
 	-docker rm ${mvn_container} > /dev/null 2>&1

--- a/ptf/run/tm/Makefile
+++ b/ptf/run/tm/Makefile
@@ -2,15 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # 320 cpu port is for mavericks (65Q)
 
-DEVICE ?= tofino
-DEVICE_CONFIG ?= "--tofino-bin /p4c-out/pipe/tofino.bin --tofino-ctx-json /p4c-out/pipe/context.json"
+DEVICE ?= stratum-bf
+
+DEVICE_CONFIG_BF := --tofino-bin /p4c-out/pipe/tofino.bin --tofino-ctx-json /p4c-out/pipe/context.json
+DEVICE_CONFIG_BFRT := --tofino-pipeline-tar /p4c-out/pipeline.tar.bz2
+
+ifeq ($(DEVICE),stratum-bfrt)
+config := $(DEVICE_CONFIG_BFRT)
+else
+config := $(DEVICE_CONFIG_BF)
+endif
 
 define run_tests
 	python -u ptf_runner.py --device $(DEVICE) --port-map port_map.veth.json \
 		--ptf-dir fabric.ptf --cpu-port 320 --device-id 1 \
 		--grpc-addr "127.0.0.1:28000" \
 		--p4info /p4c-out/p4info.txt \
-		$(DEVICE_CONFIG) \
+		$(config) \
 		$(2)
 endef
 

--- a/ptf/run/tm/run
+++ b/ptf/run/tm/run
@@ -110,13 +110,18 @@ docker run --name ${stratumBfRunName} -d --privileged \
 sleep 5
 wait_for ${stratumBfRunName} 28000 60
 
+testerDevice="stratum-bf"
+if [[ "${STRATUM_BF_DOCKER_IMG}" == *"stratum-bfrt"* ]]; then
+  echo "*** Detected stratum-bfrt..."
+  testerDevice="stratum-bfrt"
+fi
+
 echo "*** Starting ${testerRunName}..."
 docker run --name ${testerRunName} -it --privileged --rm \
     --network "container:${tmRunName}" \
     -v "${FP4TEST_ROOT}":/fabric-p4test \
     -v "${P4C_OUT}":/p4c-out \
-    -e DEVICE=stratum-bfrt \
-    -e "DEVICE_CONFIG=--tofino-pipeline-tar /p4c-out/pipeline.tar.bz2" \
+    -e DEVICE=${testerDevice} \
     --entrypoint /fabric-p4test/run/tm/start_test.sh \
     "${FP4TEST_DOCKER_IMG}" \
     ${@}

--- a/ptf/run/tm/stratum_entrypoint.sh
+++ b/ptf/run/tm/stratum_entrypoint.sh
@@ -15,7 +15,13 @@ mount -t hugetlbfs nodev /mnt/huge
 # Log files will be copied out of this container once stopped (see run.)
 mkdir /tmp/workdir
 cd /tmp/workdir
-/usr/bin/stratum_bfrt \
+
+stratumBin=/usr/bin/stratum_bf
+if test -f "/usr/bin/stratum_bfrt"; then
+    stratumBin=/usr/bin/stratum_bfrt
+fi
+
+${stratumBin} \
     -bf_sde_install=/usr \
     -bf_switchd_background=true \
     -bf_switchd_cfg=/usr/share/stratum/tofino_skip_p4.conf \

--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -104,9 +104,7 @@ class FabricIPv4UnicastGtpTest(IPv4UnicastTest):
     @autocleanup
     def runTest(self):
         # Assert that GTP packets not meant to be processed by spgw.p4 are
-        # forwarded using the outer IP+UDP headers. For spgw.p4 to kick in
-        # outer IP dst should be in a subnet defined at compile time (see
-        # fabric.p4's parser).
+        # forwarded using the outer IP+UDP headers.
         inner_udp = UDP(sport=5061, dport=5060) / ("\xab" * 128)
         pkt = Ether(src=HOST1_MAC, dst=SWITCH_MAC) / \
               IP(src=HOST3_IPV4, dst=HOST4_IPV4) / \

--- a/ptf/tests/ptf/ptf_runner.py
+++ b/ptf/tests/ptf/ptf_runner.py
@@ -243,7 +243,7 @@ def main():
     parser.add_argument('--device',
                         help='Target device',
                         type=str, action="store", required=True,
-                        choices=['tofino', 'bmv2', 'stratum-bmv2', 'stratum-bfrt'])
+                        choices=['stratum-bf', 'bmv2', 'stratum-bmv2', 'stratum-bfrt'])
     parser.add_argument('--p4info',
                         help='Location of p4info proto in text format',
                         type=str, action="store", required=True)
@@ -297,7 +297,7 @@ def main():
     if not os.path.exists(args.p4info):
         error("P4Info file {} not found".format(args.p4info))
         sys.exit(1)
-    if device == 'tofino':
+    if device == 'stratum-bf':
         if not os.path.exists(args.tofino_bin):
             error("Tofino binary config file {} not found".format(
                 args.tofino_bin))


### PR DESCRIPTION
Before, scripts were always assuming stratum-bfrt (and the tarball-based way of pushing the pipeline)