### PR TITLE
[DO NOT MERGE] Add platform specific defines that are also exposed in p4info

### DIFF
--- a/p4src/build.sh
+++ b/p4src/build.sh
@@ -42,7 +42,13 @@ function do_p4c() {
   cpu_port=$2
   echo "*** Compiling profile '${PROFILE}' for ${pltf} platform..."
   echo "*** Output in ${P4C_OUT}/${pltf}"
-  pp_flags="-DCPU_PORT=${cpu_port}"
+  pp_flags=""
+  if [[ "$1" == "montara" ]]; then
+    pp_flags="-DCPU_PORT=${cpu_port} -DTARGET_TOFINO_CHIP_32D=1"
+  else
+    pp_flags="-DCPU_PORT=${cpu_port} -DTARGET_TOFINO_CHIP_64D=1"
+  fi
+  echo "pp_flags=$pp_flags"
   p4c_flags="--auto-init-metadata"
   mkdir -p ${P4C_OUT}/${pltf}
   (

--- a/p4src/fabric_tna.p4
+++ b/p4src/fabric_tna.p4
@@ -4,6 +4,7 @@
 #include <core.p4>
 #include <tna.p4>
 
+#include "include/platform.p4"
 #include "include/define.p4"
 #include "include/size.p4"
 #include "include/header.p4"
@@ -96,4 +97,5 @@ Pipeline(
     FabricEgressDeparser()
 ) pipe;
 
+PLATFORM_ANNOTATION
 Switch(pipe) main;

--- a/p4src/include/platform.p4
+++ b/p4src/include/platform.p4
@@ -1,0 +1,33 @@
+// Copyright 2020-present Open Networking Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __PLATFORM__
+#define __PLATFORM__
+
+#if defined(TARGET_TOFINO_CHIP_32D)
+#define _NUM_HW_PIPES 2
+#define _TOFINO_CHIP_NAME "TOFINO_32D"
+#define _CPU_PORT_PCIE 192
+#define _LAST_PORT 255
+
+#elif defined(TARGET_TOFINO_CHIP_64D)
+#define _NUM_HW_PIPES 4
+#define _TOFINO_CHIP_NAME "TOFINO_64D"
+#define _CPU_PORT_PCIE 320
+#define _LAST_PORT 511
+
+#else
+#error "Must define a TARGET_TOFINO_CHIP_X"
+#endif
+
+// This is the platform annotation to be placed on the main Switch().
+#define PLATFORM_ANNOTATION \
+    @chip(_TOFINO_CHIP_NAME) \
+    @num_hw_pipes(_NUM_HW_PIPES) \
+    @cpu_port_pcie(_CPU_PORT_PCIE) \
+    @last_port(_LAST_PORT)
+
+// Export information with proper types.
+const bit<9> CPU_PORT_PCIE = _CPU_PORT_PCIE;
+
+#endif // __PLATFORM__


### PR DESCRIPTION
This is a counter proposal to #40 that pulls the platform specifc information up to the switch OS and controller, instead of trying to hide/contain it in the P4 program.

P4 has the concept of [package information](https://p4.org/p4-spec/docs/P4-16-v1.1.0-spec.html#sec-package-anno), which can contain user-set information about the P4 program. Sadly the keys are defined by the P4WG and not user-extensible. But we're free to annotate the main `Switch()` statement itself with free-form annotations.

Together with a header that defines platform specific constants, values or limits, this allows us to convey this information upwards. The header will check and enforce the presence of a `TARGET_TOFINO_CHIP_X` define, either from including code or on the compiler command line, which allows selecting a platform.

Example (after pre-processing, for clarity):

platform.p4
```p4
#if defined(TARGET_TOFINO_CHIP_32D)
#define _NUM_HW_PIPES 2
#define _TOFINO_CHIP_NAME "TOFINO_32D"
#define _CPU_PORT_PCIE 192
#define _LAST_PORT 255
...
```

fabric.p4
```p4
@chip("TOFINO_64D")
@num_hw_pipes(4)
@cpu_port_pcie(320)
@last_port(511)
Switch(pipe) main;
```

Which will yield the following p4info:
```protobuf
pkg_info {
  annotations: "@chip(\"TOFINO_64D\")"
  annotations: "@num_hw_pipes(4)"
  annotations: "@cpu_port_pcie(320)"
  annotations: "@last_port(511)"
  arch: "tna"
}
```

This change is compatible with both other controllers, switches or programs, as interpreting or inserting these annotations is optional.

Other benefits:

- Stratum could check if the pushed program and underlying hardware overlap, eliminating source of user errors
- ONOS could make decisions based on chip type, e.g., number of clone sessions