### PR TITLE
First draft of register tests

### DIFF
--- a/p4src/include/int/int.p4
+++ b/p4src/include/int/int.p4
@@ -17,6 +17,7 @@ control IntEgress (
     Random<bit<16>>() ip_id_gen;
     @hidden
     @switchstack("register_clear_interval_ms: 1000")
+    @switchstack("register_clear_value: 0")
     Register<bit<32>, bit<6>>(1024) seq_number;
     RegisterAction<bit<32>, bit<6>, bit<32>>(seq_number) get_seq_number = {
         void apply(inout bit<32> reg, out bit<32> rv) {

--- a/ptf/tests/ptf/base_test.py
+++ b/ptf/tests/ptf/base_test.py
@@ -777,12 +777,13 @@ class P4RuntimeTest(BaseTest):
 
         return req, self.write_request(req, store=False)
 
-    def read_register(self, reg_name, index):
+    def read_register(self, reg_name, index=None):
         req = self.get_new_read_request()
         entity = req.entities.add()
         register_entry = entity.register_entry
         register_entry.register_id = self.get_register_id(reg_name)
-        register_entry.index.index = index
+        if index is not None:
+            register_entry.index.index = index
 
         for entity in self.read_request(req):
             if entity.HasField("register_entry"):
@@ -929,6 +930,41 @@ class P4RuntimeTest(BaseTest):
                 if counter_entry.data.byte_count != expected_byte_count or \
                         counter_entry.data.packet_count != expected_packet_count:
                     self.fail("Incorrect direct counter value:\n" + str(dcounter))
+        return None
+
+    def verify_register(self, reg_name, index, expected_data):
+        reg = self.read_register(reg_name, index)
+        if reg.index.index != index:
+            self.fail("Incorrect index\n" + format_exp_rcv(index, reg.index.index))
+        if reg.data != expected_data:
+            self.fail("Incorrect data:\n" + format_exp_rcv(expected_data, reg.data))
+
+        return None
+
+        # TODO: check about tv generation
+        req = self.get_new_read_request()
+        entity = req.entities.add()
+        direct_counter_entry = entity.direct_counter_entry
+        direct_counter_entry.table_entry.CopyFrom(table_entry)
+
+        if self.generate_tv:
+            exp_resp = self.get_new_read_response()
+            entity = exp_resp.entities.add()
+            entity.direct_counter_entry.table_entry.CopyFrom(table_entry)
+            entity.direct_counter_entry.data.byte_count = expected_byte_count
+            entity.direct_counter_entry.data.packet_count = expected_packet_count
+            # add to list
+            exp_resps = []
+            exp_resps.append(exp_resp)
+            tvutils.add_read_expectation(self.tc, req, exp_resps)
+            return None
+
+        for entity in self.read_request(req):
+            if entity.HasField("direct_counter_entry"):
+                direct_counter = entity.direct_counter_entry
+                if direct_counter.data.byte_count != expected_byte_count or \
+                        direct_counter.data.packet_count != expected_packet_count:
+                    self.fail("Incorrect direct counter value:\n" + str(direct_counter))
         return None
 
     def is_default_action_update(self, update):

--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -1027,17 +1027,25 @@ class RegisterTest(FabricTest):
     @tvsetup
     @autocleanup
     def doRunTest(self):
+        register_name = "pipe.FabricEgress.int_egress.seq_number"
         index = 1
-        reg = self.read_register("pipe.FabricEgress.int_egress.seq_number", index)
-        print(reg)
+        default_data = p4data_pb2.P4Data()
+        default_data.bitstring = stringify(0x0, 1)
+        # Check that the default reset value is written.
+        self.verify_register(register_name, index, default_data)
 
+        # Write a new value and verify be reading it back.
         data = p4data_pb2.P4Data()
-        data.bitstring = stringify(1234, 4)
-        req, _ = self.write_register("pipe.FabricEgress.int_egress.seq_number", index, data)
+        data.bitstring = stringify(0xabcd, 2)
+        req, _ = self.write_register(register_name, index, data)
+        self.verify_register(register_name, index, data)
 
-        print(self.read_register("pipe.FabricEgress.int_egress.seq_number", index))
+        # Check the regular register reset.
         time.sleep(3)
-        print(self.read_register("pipe.FabricEgress.int_egress.seq_number", index))
+        self.verify_register(register_name, index, default_data)
+
+        # Wildcard read
+        self.read_register(register_name)
 
     def runTest(self):
         print("")


### PR DESCRIPTION
Adds a simple read write test for the register in the int profile.

Also introduces the Stratum specific annotation for registers: `@stratum("clear_interval_ms: 1")`

TODO:

- [ ] Dataplane tests