### PR TITLE
Refactor mirror

### DIFF
--- a/p4src/fabric_tna.p4
+++ b/p4src/fabric_tna.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #include <core.p4>
 #include <tna.p4>
@@ -96,7 +96,7 @@ control FabricEgress (
 #endif // WITH_INT
         pkt_io_egress.apply(hdr, fabric_md, eg_intr_md);
 #ifdef WITH_INT
-        int_egress.apply(hdr, fabric_md, eg_intr_md, eg_prsr_md);
+        int_egress.apply(hdr, fabric_md, eg_intr_md, eg_prsr_md, eg_dprsr_md);
 #endif
         egress_next.apply(hdr, fabric_md, eg_intr_md, eg_dprsr_md);
 #ifdef WITH_SPGW

--- a/p4src/include/control/spgw.p4
+++ b/p4src/include/control/spgw.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __SPGW__
 #define __SPGW__
@@ -319,7 +319,7 @@ control SpgwEgress(
         hdr.outer_gtpu.teid = fabric_md.bridged.spgw.gtpu_teid;
 
 #ifdef WITH_INT
-            fabric_md.int_mirror_md.strip_gtpu = 1;
+            fabric_md.int_mirror.strip_gtpu = 1;
 #endif // WITH_INT
     }
 

--- a/p4src/include/define.p4
+++ b/p4src/include/define.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #include <tna.p4>
 
@@ -105,13 +105,18 @@ action nop() {
     NoAction();
 }
 
-// Bridge metadata type
-enum bit<8> BridgedMdType_t {
+enum bit<8> BridgeType_t {
     INVALID = 0,
-    // Ingress to egress.
-    I2E = 1,
-    // Egress to egress mirror used for INT reports.
-    INT_MIRROR = 2
+    INGRESS_TO_EGRESS = 1,
+    INGRESS_MIRROR = 2,
+    EGRESS_MIRROR = 3
+}
+
+enum bit<3> MirrorType_t {
+    INVALID = 0,
+    SIMPLE = 1,
+    INT_LOCAL_REPORT = 2,
+    INT_DROP_REPORT = 3
 }
 
 // Modes for CPU loopback testing, where a process can inject packets through

--- a/p4src/include/header.p4
+++ b/p4src/include/header.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __HEADER__
 #define __HEADER__
@@ -134,6 +134,11 @@ header gtpu_t {
 
 // Custom metadata definition
 
+header common_egress_metadata_t {
+    BridgeType_t    bridge_type;
+    @padding bit<5> _pad;
+    MirrorType_t    mirror_type;
+}
 
 #ifdef WITH_SPGW
 struct spgw_bridged_metadata_t {
@@ -161,26 +166,26 @@ struct spgw_ingress_metadata_t {
 // ingress and egress pipeline.
 @flexible
 header bridged_metadata_t {
-    BridgedMdType_t bridged_md_type;
-    bool            is_multicast;
-    fwd_type_t      fwd_type;
-    PortId_t        ig_port;
-    vlan_id_t       vlan_id;
-    // bit<3>          vlan_pri;
-    // bit<1>          vlan_cfi;
-    mpls_label_t    mpls_label;
-    bit<8>          mpls_ttl;
-    bit<48>         ig_tstamp;
-    bit<16>         ip_eth_type;
-    bit<8>          ip_proto;
-    l4_port_t       l4_sport;
-    l4_port_t       l4_dport;
-    flow_hash_t     flow_hash;
+    BridgeType_t            bridge_type;
+    bool                    is_multicast;
+    fwd_type_t              fwd_type;
+    PortId_t                ig_port;
+    vlan_id_t               vlan_id;
+    // bit<3>                  vlan_pri;
+    // bit<1>                  vlan_cfi;
+    mpls_label_t            mpls_label;
+    bit<8>                  mpls_ttl;
+    bit<48>                 ig_tstamp;
+    bit<16>                 ip_eth_type;
+    bit<8>                  ip_proto;
+    l4_port_t               l4_sport;
+    l4_port_t               l4_dport;
+    flow_hash_t             flow_hash;
 #ifdef WITH_DOUBLE_VLAN_TERMINATION
-    bool            push_double_vlan;
-    vlan_id_t       inner_vlan_id;
-    // bit<3>          inner_vlan_pri;
-    // bit<1>          inner_vlan_cfi;
+    bool                    push_double_vlan;
+    vlan_id_t               inner_vlan_id;
+    // bit<3>                  inner_vlan_pri;
+    // bit<1>                  inner_vlan_cfi;
 #endif // WITH_DOUBLE_VLAN_TERMINATION
 #ifdef WITH_SPGW
     l4_port_t               inner_l4_sport;
@@ -189,10 +194,21 @@ header bridged_metadata_t {
 #endif // WITH_SPGW
 }
 
+@flexible
+@pa_no_overlay("egress", "fabric_md.mirror.bridge_type")
+@pa_no_overlay("egress", "fabric_md.mirror.mirror_type")
+@pa_no_overlay("egress", "fabric_md.mirror.mirror_session_id")
+header mirror_metadata_t {
+    BridgeType_t    bridge_type;
+    MirrorType_t    mirror_type;
+    MirrorId_t      mirror_session_id;
+}
+
 // Ingress pipeline-only metadata
 @flexible
 struct fabric_ingress_metadata_t {
     bridged_metadata_t      bridged;
+    mirror_metadata_t       mirror;
     bit<32>                 ipv4_src;
     bit<32>                 ipv4_dst;
     bool                    ipv4_checksum_err;
@@ -203,19 +219,23 @@ struct fabric_ingress_metadata_t {
     bool                    inner_ipv4_checksum_err;
     spgw_ingress_metadata_t spgw;
 #endif // WITH_SPGW
+#ifdef WITH_INT
+    int_mirror_metadata_t   int_mirror;
+#endif // WITH_INT
 }
 
 // Egress pipeline-only metadata
 @flexible
 struct fabric_egress_metadata_t {
     bridged_metadata_t    bridged;
+    mirror_metadata_t     mirror;
     PortId_t              cpu_port;
 #ifdef WITH_SPGW
     bool                  inner_ipv4_checksum_err;
 #endif // WITH_SPGW
     bit<1>                mpls_stripped;
 #ifdef WITH_INT
-    int_mirror_metadata_t int_mirror_md;
+    int_mirror_metadata_t int_mirror;
 #endif // WITH_INT
 }
 
@@ -259,6 +279,7 @@ struct parsed_headers_t {
     ipv4_t report_ipv4;
     udp_t report_udp;
     report_fixed_header_t report_fixed_header;
+    common_report_header_t common_report_header;
     local_report_header_t local_report_header;
 #endif // WITH_INT
 }

--- a/p4src/include/int/define.p4
+++ b/p4src/include/int/define.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __INT_DEFINE__
 #define __INT_DEFINE__
@@ -16,9 +16,9 @@ const bit<16> REPORT_FIXED_HEADER_BYTES = 12;
 const bit<16> DROP_REPORT_HEADER_BYTES = 12;
 const bit<16> LOCAL_REPORT_HEADER_BYTES = 16;
 #ifdef WITH_SPGW
-const bit<16> REPORT_MIRROR_HEADER_BYTES = 24;
+const bit<16> REPORT_MIRROR_HEADER_BYTES = 26;
 #else
-const bit<16> REPORT_MIRROR_HEADER_BYTES = 23;
+const bit<16> REPORT_MIRROR_HEADER_BYTES = 25;
 #endif // WITH_SPGW
 const bit<16> ETH_FCS_LEN = 4;
 

--- a/p4src/include/int/header.p4
+++ b/p4src/include/int/header.p4
@@ -1,12 +1,12 @@
 // Copyright 2017-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __INT_HEADER__
 #define __INT_HEADER__
 
 #include "define.p4"
 
-// Report Telemetry Headers
+// Report Telemetry Headers v0.5
 header report_fixed_header_t {
     bit<4>  ver;
     bit<4>  nproto;
@@ -19,22 +19,21 @@ header report_fixed_header_t {
     bit<32> ig_tstamp;
 }
 
-// Telemetry drop report header
-header drop_report_header_t {
+header common_report_header_t {
     bit<32> switch_id;
     bit<16> ig_port;
     bit<16> eg_port;
     bit<8>  queue_id;
+}
+
+// Telemetry drop report header
+header drop_report_header_t {
     bit<8>  drop_reason;
     bit<16> pad;
 }
 
 // Switch Local Report Header
 header local_report_header_t {
-    bit<32> switch_id;
-    bit<16> ig_port;
-    bit<16> eg_port;
-    bit<8>  queue_id;
     bit<24> queue_occupancy;
     bit<32> eg_tstamp;
 }
@@ -49,33 +48,36 @@ header_union local_report_t {
 // may mark the mirror metadata and other headers (e.g., IPv4)
 // as "mutually exclusive".
 // Here we set the mirror metadata with "no overlay" to prevent this.
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.bridged_md_type")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.mirror_session_id")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.switch_id")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.ig_port")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.eg_port")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.queue_id")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.queue_occupancy")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.ig_tstamp")
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.eg_tstamp")
+@pa_no_overlay("egress", "fabric_md.int_mirror.bridge_type")
+@pa_no_overlay("egress", "fabric_md.int_mirror.mirror_type")
+@pa_no_overlay("egress", "fabric_md.int_mirror.mirror_session_id")
+@pa_no_overlay("egress", "fabric_md.int_mirror.switch_id")
+@pa_no_overlay("egress", "fabric_md.int_mirror.ig_port")
+@pa_no_overlay("egress", "fabric_md.int_mirror.eg_port")
+@pa_no_overlay("egress", "fabric_md.int_mirror.queue_id")
+@pa_no_overlay("egress", "fabric_md.int_mirror.queue_occupancy")
+@pa_no_overlay("egress", "fabric_md.int_mirror.ig_tstamp")
+@pa_no_overlay("egress", "fabric_md.int_mirror.eg_tstamp")
 #ifdef WITH_SPGW
-@pa_no_overlay("egress", "fabric_md.int_mirror_md.strip_gtpu")
+@pa_no_overlay("egress", "fabric_md.int_mirror.strip_gtpu")
 #endif // WITH_SPGW
 header int_mirror_metadata_t {
-    BridgedMdType_t bridged_md_type;
-    bit<6>                _pad0;
-    MirrorId_t            mirror_session_id;
-    bit<32>               switch_id;
-    bit<16>               ig_port;
-    bit<16>               eg_port;
-    bit<8>                queue_id;
-    bit<24>               queue_occupancy;
-    bit<32>               ig_tstamp;
-    bit<32>               eg_tstamp;
+    BridgeType_t    bridge_type;
+    @padding bit<5> _pad0;
+    MirrorType_t    mirror_type;
+    @padding bit<6> _pad1;
+    MirrorId_t      mirror_session_id;
+    bit<32>         switch_id;
+    bit<16>         ig_port;
+    bit<16>         eg_port;
+    bit<8>          queue_id;
+    bit<24>         queue_occupancy;
+    bit<32>         ig_tstamp;
+    bit<32>         eg_tstamp;
+    bit<8>          drop_reason;
 #ifdef WITH_SPGW
-    bit<7>                _pad1;
-    bit<1>                strip_gtpu;
+    @padding bit<7> _pad2;
+    bit<1>          strip_gtpu;
 #endif // WITH_SPGW
 }
-
 #endif // __INT_HEADER__

--- a/p4src/include/int/int.p4
+++ b/p4src/include/int/int.p4
@@ -1,5 +1,5 @@
 // Copyright 2017-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __INT_MAIN__
 #define __INT_MAIN__
@@ -12,7 +12,8 @@ control FlowReportFilter(
     inout parsed_headers_t hdr,
     inout fabric_egress_metadata_t fabric_md,
     in    egress_intrinsic_metadata_t eg_intr_md,
-    in    egress_intrinsic_metadata_from_parser_t eg_prsr_md) {
+    in    egress_intrinsic_metadata_from_parser_t eg_prsr_md,
+    inout egress_intrinsic_metadata_for_deparser_t eg_dprsr_md) {
 
     Hash<bit<16>>(HashAlgorithm_t.CRC16) flow_state_hasher;
     bit<16> flow_state_hash;
@@ -80,7 +81,7 @@ control FlowReportFilter(
         flags = filter_get_and_set1.execute(fabric_md.bridged.flow_hash[31:16]);
         flags = flags | filter_get_and_set2.execute(fabric_md.bridged.flow_hash[15:0]);
         if (flags == 0b01) {
-            fabric_md.int_mirror_md.setInvalid();
+            eg_dprsr_md.mirror_type = (bit<3>)MirrorType_t.INVALID;
         }
     }
 }
@@ -89,7 +90,8 @@ control IntEgress (
     inout parsed_headers_t hdr,
     inout fabric_egress_metadata_t fabric_md,
     in    egress_intrinsic_metadata_t eg_intr_md,
-    in    egress_intrinsic_metadata_from_parser_t eg_prsr_md) {
+    in    egress_intrinsic_metadata_from_parser_t eg_prsr_md,
+    inout egress_intrinsic_metadata_for_deparser_t eg_dprsr_md) {
 
     FlowReportFilter() flow_report_filter;
 
@@ -113,15 +115,16 @@ control IntEgress (
         hdr.report_fixed_header.q = 0;
         hdr.report_fixed_header.f = 1;
         hdr.report_fixed_header.rsvd = 0;
-        hdr.report_fixed_header.ig_tstamp = fabric_md.int_mirror_md.ig_tstamp;
+        hdr.report_fixed_header.ig_tstamp = fabric_md.int_mirror.ig_tstamp;
 
+        hdr.common_report_header.setValid();
+        hdr.common_report_header.switch_id = fabric_md.int_mirror.switch_id;
+        hdr.common_report_header.ig_port = fabric_md.int_mirror.ig_port;
+        hdr.common_report_header.eg_port = fabric_md.int_mirror.eg_port;
+        hdr.common_report_header.queue_id = fabric_md.int_mirror.queue_id;
         hdr.local_report_header.setValid();
-        hdr.local_report_header.switch_id = fabric_md.int_mirror_md.switch_id;
-        hdr.local_report_header.ig_port = fabric_md.int_mirror_md.ig_port;
-        hdr.local_report_header.eg_port = fabric_md.int_mirror_md.eg_port;
-        hdr.local_report_header.queue_id = fabric_md.int_mirror_md.queue_id;
-        hdr.local_report_header.queue_occupancy = fabric_md.int_mirror_md.queue_occupancy;
-        hdr.local_report_header.eg_tstamp = fabric_md.int_mirror_md.eg_tstamp;
+        hdr.local_report_header.queue_occupancy = fabric_md.int_mirror.queue_occupancy;
+        hdr.local_report_header.eg_tstamp = fabric_md.int_mirror.eg_tstamp;
     }
 
     action do_report_encap(mac_addr_t src_mac, mac_addr_t mon_mac,
@@ -176,7 +179,7 @@ control IntEgress (
 
     table report {
         key = {
-            fabric_md.int_mirror_md.isValid(): exact @name("int_mirror_valid");
+            fabric_md.int_mirror.mirror_type: exact;
         }
         actions = {
             do_report_encap;
@@ -184,7 +187,7 @@ control IntEgress (
             @defaultonly nop();
         }
         default_action = nop;
-        const size = 1;
+        const size = 2; // Drop report and local report
     }
 
     @hidden
@@ -211,17 +214,19 @@ control IntEgress (
     }
 
     action init_metadata(bit<32> switch_id) {
-        fabric_md.int_mirror_md.setValid();
-        fabric_md.int_mirror_md.bridged_md_type = BridgedMdType_t.INT_MIRROR;
-        fabric_md.int_mirror_md.switch_id = switch_id;
-        fabric_md.int_mirror_md.ig_port = (bit<16>)fabric_md.bridged.ig_port;
-        fabric_md.int_mirror_md.eg_port = (bit<16>)eg_intr_md.egress_port;
-        fabric_md.int_mirror_md.queue_id = (bit<8>)eg_intr_md.egress_qid;
-        fabric_md.int_mirror_md.queue_occupancy = (bit<24>)eg_intr_md.enq_qdepth;
-        fabric_md.int_mirror_md.ig_tstamp = fabric_md.bridged.ig_tstamp[31:0];
-        fabric_md.int_mirror_md.eg_tstamp = eg_prsr_md.global_tstamp[31:0];
+        fabric_md.int_mirror.setValid();
+        fabric_md.int_mirror.bridge_type = BridgeType_t.EGRESS_MIRROR;
+        fabric_md.int_mirror.mirror_type = MirrorType_t.INT_LOCAL_REPORT;
+        eg_dprsr_md.mirror_type = (bit<3>)MirrorType_t.INT_LOCAL_REPORT;
+        fabric_md.int_mirror.switch_id = switch_id;
+        fabric_md.int_mirror.ig_port = (bit<16>)fabric_md.bridged.ig_port;
+        fabric_md.int_mirror.eg_port = (bit<16>)eg_intr_md.egress_port;
+        fabric_md.int_mirror.queue_id = (bit<8>)eg_intr_md.egress_qid;
+        fabric_md.int_mirror.queue_occupancy = (bit<24>)eg_intr_md.enq_qdepth;
+        fabric_md.int_mirror.ig_tstamp = fabric_md.bridged.ig_tstamp[31:0];
+        fabric_md.int_mirror.eg_tstamp = eg_prsr_md.global_tstamp[31:0];
 #ifdef WITH_SPGW
-        fabric_md.int_mirror_md.strip_gtpu = (bit<1>)(hdr.gtpu.isValid());
+        fabric_md.int_mirror.strip_gtpu = (bit<1>)(hdr.gtpu.isValid());
 #endif // WITH_SPGW
     }
 
@@ -243,7 +248,8 @@ control IntEgress (
 
     @hidden
     action set_mirror_session_id(MirrorId_t sid) {
-        fabric_md.int_mirror_md.mirror_session_id = sid;
+        fabric_md.int_mirror.mirror_session_id = sid;
+        fabric_md.mirror.mirror_session_id = sid;
     }
 
     @hidden
@@ -265,13 +271,14 @@ control IntEgress (
 
     apply {
         if (report.apply().hit) {
+            // Is a mirror packet for INT drop/local report.
             report_seq_no_and_hw_id.apply();
             // Remove the INT mirror metadata to prevent egress mirroring again.
-            fabric_md.int_mirror_md.setInvalid();
+            fabric_md.mirror.mirror_type = MirrorType_t.INVALID;
+            eg_dprsr_md.mirror_type = (bit<3>)MirrorType_t.INVALID;
 #ifdef WITH_SPGW
-            if (fabric_md.int_mirror_md.strip_gtpu == 1) {
+            if (fabric_md.int_mirror.strip_gtpu == 1) {
                 // We need to remove length of IP, UDP, and GTPU headers
-                // since we only monitor the packet inside the GTP tunnel.
                 hdr.report_ipv4.total_len = hdr.report_ipv4.total_len
                     - (IPV4_HDR_BYTES + UDP_HDR_BYTES + GTP_HDR_BYTES);
                 hdr.report_udp.len = hdr.report_udp.len
@@ -292,7 +299,7 @@ control IntEgress (
             mirror_session_id.apply();
             if (hdr.ipv4.isValid()) {
                 if (watchlist.apply().hit) {
-                    flow_report_filter.apply(hdr, fabric_md, eg_intr_md, eg_prsr_md);
+                    flow_report_filter.apply(hdr, fabric_md, eg_intr_md, eg_prsr_md, eg_dprsr_md);
                 }
             }
         }

--- a/p4src/include/parser.p4
+++ b/p4src/include/parser.p4
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef __PARSER__
 #define __PARSER__
@@ -22,7 +22,7 @@ parser FabricIngressParser (packet_in  packet,
         packet.extract(ig_intr_md);
         packet.advance(PORT_METADATA_SIZE);
         fabric_md.bridged.setValid();
-        fabric_md.bridged.bridged_md_type = BridgedMdType_t.I2E;
+        fabric_md.bridged.bridge_type = BridgeType_t.INGRESS_TO_EGRESS;
         fabric_md.bridged.ig_port = ig_intr_md.ingress_port;
         fabric_md.bridged.ig_tstamp = ig_intr_md.ingress_mac_tstamp;
         transition check_ethernet;
@@ -225,14 +225,34 @@ parser FabricIngressParser (packet_in  packet,
 #endif // WITH_SPGW
 }
 
+control FabricIngressMirror(
+    in fabric_ingress_metadata_t fabric_md,
+    in ingress_intrinsic_metadata_for_deparser_t ig_intr_md_for_dprsr) {
+    Mirror() mirror;
+    apply {
+        if (ig_intr_md_for_dprsr.mirror_type == (bit<3>)MirrorType_t.SIMPLE) {
+            mirror.emit<mirror_metadata_t>(fabric_md.mirror.mirror_session_id,
+                                           fabric_md.mirror);
+        }
+#ifdef WITH_INT
+        else if (ig_intr_md_for_dprsr.mirror_type == (bit<3>)MirrorType_t.INT_DROP_REPORT) {
+            mirror.emit<int_mirror_metadata_t>(fabric_md.mirror.mirror_session_id,
+                                               fabric_md.int_mirror);
+        }
+#endif // WITH_INT
+    }
+}
+
 control FabricIngressDeparser(packet_out packet,
     /* Fabric.p4 */
     inout parsed_headers_t hdr,
     in fabric_ingress_metadata_t fabric_md,
     /* TNA */
     in ingress_intrinsic_metadata_for_deparser_t ig_intr_md_for_dprsr) {
+    FabricIngressMirror() ingress_mirror;
 
     apply {
+        ingress_mirror.apply(fabric_md, ig_intr_md_for_dprsr);
         packet.emit(fabric_md.bridged);
         packet.emit(hdr.fake_ethernet);
         packet.emit(hdr.packet_in);
@@ -272,29 +292,42 @@ parser FabricEgressParser (packet_in packet,
     bit<1> is_int_and_strip_gtpu = 0;
 #endif // defined(WITH_INT) && defined(WITH_SPGW)
 
+#ifdef WITH_INT
+    int_mirror_metadata_t int_mirror;
+#endif
+
     state start {
         packet.extract(eg_intr_md);
         fabric_md.cpu_port = 0;
-        BridgedMdType_t bridged_md_type = packet.lookahead<BridgedMdType_t>();
-        transition select(bridged_md_type) {
-            BridgedMdType_t.I2E: parse_bridged_md;
-            BridgedMdType_t.INT_MIRROR: parse_int_mirror_md;
+        common_egress_metadata_t common_eg_md = packet.lookahead<common_egress_metadata_t>();
+        transition select(common_eg_md.bridge_type, common_eg_md.mirror_type) {
+            (BridgeType_t.INGRESS_TO_EGRESS, _): parse_bridged_md;
+            (BridgeType_t.INGRESS_MIRROR, MirrorType_t.SIMPLE):  parse_simple_mirror;
+            (BridgeType_t.EGRESS_MIRROR, MirrorType_t.SIMPLE):  parse_simple_mirror;
+#ifdef WITH_INT
+            (BridgeType_t.INGRESS_MIRROR, MirrorType_t.INT_DROP_REPORT):  parse_int_report_mirror;
+            (BridgeType_t.EGRESS_MIRROR,  MirrorType_t.INT_DROP_REPORT):  parse_int_report_mirror;
+            (BridgeType_t.EGRESS_MIRROR,  MirrorType_t.INT_LOCAL_REPORT): parse_int_report_mirror;
+#endif // WITH_INT
             default: reject;
         }
     }
 
     state parse_bridged_md {
         packet.extract(fabric_md.bridged);
+#if defined(WITH_INT) && defined(WITH_SPGW)
+        is_int_and_strip_gtpu = 0;
+#endif // defined(WITH_INT) && defined(WITH_SPGW)
         transition check_ethernet;
     }
 
-    state parse_int_mirror_md {
+    state parse_int_report_mirror {
 #ifdef WITH_INT
-        packet.extract(fabric_md.int_mirror_md);
-        fabric_md.bridged.bridged_md_type = fabric_md.int_mirror_md.bridged_md_type;
+        packet.extract(fabric_md.int_mirror);
+        fabric_md.bridged.bridge_type = fabric_md.int_mirror.bridge_type;
         fabric_md.bridged.vlan_id = DEFAULT_VLAN_ID;
 #ifdef WITH_SPGW
-        is_int_and_strip_gtpu = fabric_md.int_mirror_md.strip_gtpu;
+        is_int_and_strip_gtpu = fabric_md.int_mirror.strip_gtpu;
 #endif // WITH_SPGW
         transition check_ethernet;
 #else
@@ -316,6 +349,12 @@ parser FabricEgressParser (packet_in packet,
         hdr.fake_ethernet.setValid();
         hdr.fake_ethernet.ether_type = ETHERTYPE_CPU_LOOPBACK_EGRESS;
         packet.advance(ETH_HDR_BYTES * 8);
+        transition parse_ethernet;
+    }
+
+    state parse_simple_mirror {
+        packet.extract(fabric_md.mirror);
+        fabric_md.bridged.bridge_type = fabric_md.mirror.bridge_type;
         transition parse_ethernet;
     }
 
@@ -488,13 +527,21 @@ parser FabricEgressParser (packet_in packet,
 
 control FabricEgressMirror(
     in parsed_headers_t hdr,
-    in fabric_egress_metadata_t fabric_md) {
+    in fabric_egress_metadata_t fabric_md,
+    in egress_intrinsic_metadata_for_deparser_t ig_intr_md_for_dprsr) {
     Mirror() mirror;
     apply {
+        if (ig_intr_md_for_dprsr.mirror_type == (bit<3>)MirrorType_t.SIMPLE) {
+            mirror.emit<mirror_metadata_t>(fabric_md.mirror.mirror_session_id,
+                                           fabric_md.mirror);
+        }
 #ifdef WITH_INT
-        if (fabric_md.int_mirror_md.isValid()) {
-            mirror.emit<int_mirror_metadata_t>(fabric_md.int_mirror_md.mirror_session_id,
-                                               fabric_md.int_mirror_md);
+        else if (ig_intr_md_for_dprsr.mirror_type == (bit<3>)MirrorType_t.INT_DROP_REPORT) {
+            mirror.emit<int_mirror_metadata_t>(fabric_md.mirror.mirror_session_id,
+                                               fabric_md.int_mirror);
+        } else if (ig_intr_md_for_dprsr.mirror_type == (bit<3>)MirrorType_t.INT_LOCAL_REPORT) {
+            mirror.emit<int_mirror_metadata_t>(fabric_md.mirror.mirror_session_id,
+                                               fabric_md.int_mirror);
         }
 #endif // WITH_INT
     }
@@ -511,6 +558,9 @@ control FabricEgressDeparser(packet_out packet,
 #ifdef WITH_SPGW
     Checksum() outer_ipv4_checksum;
 #endif // WITH_SPGW
+#ifdef WITH_INT
+    Checksum() report_ipv4_checksum;
+#endif // WITH_INT
 
     apply {
         if (hdr.ipv4.isValid()) {
@@ -550,7 +600,7 @@ control FabricEgressDeparser(packet_out packet,
 #endif // WITH_SPGW
 #ifdef WITH_INT
         if (hdr.report_ipv4.isValid()) {
-            hdr.report_ipv4.hdr_checksum = ipv4_checksum.update({
+            hdr.report_ipv4.hdr_checksum = report_ipv4_checksum.update({
                 hdr.report_ipv4.version,
                 hdr.report_ipv4.ihl,
                 hdr.report_ipv4.dscp,
@@ -566,7 +616,7 @@ control FabricEgressDeparser(packet_out packet,
             });
         }
 #endif // WITH_INT
-        egress_mirror.apply(hdr, fabric_md);
+        egress_mirror.apply(hdr, fabric_md, eg_intr_md_for_dprsr);
 
         packet.emit(hdr.fake_ethernet);
         packet.emit(hdr.packet_in);
@@ -577,6 +627,7 @@ control FabricEgressDeparser(packet_out packet,
         packet.emit(hdr.report_ipv4);
         packet.emit(hdr.report_udp);
         packet.emit(hdr.report_fixed_header);
+        packet.emit(hdr.common_report_header);
         packet.emit(hdr.local_report_header);
 #endif // WITH_INT
         packet.emit(hdr.ethernet);

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -1,6 +1,6 @@
-# Copyright 2013-2018 Barefoot Networks, Inc.
+# Copyright 2013-present Barefoot Networks, Inc.
 # Copyright 2018-present Open Networking Foundation
-# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 
 import socket
 import struct
@@ -185,6 +185,10 @@ PPPOED_CODES = (
     PPPOED_CODE_PADT,
 )
 
+MIRROR_TYPE_INVALID = 0
+MIRROR_TYPE_SIMPLE = 1
+MIRROR_TYPE_INT_LOCAL_REPORT = 2
+MIRROR_TYPE_INT_DROP_REPORT = 3
 
 class GTPU(Packet):
     name = "GTP-U Header"
@@ -332,7 +336,7 @@ class FabricTest(P4RuntimeTest):
 
     def build_packet_out(self, pkt, port, cpu_loopback_mode=CPU_LOOPBACK_MODE_DISABLED):
         packet_out = p4runtime_pb2.PacketOut()
-        packet_out.payload = bytes(pkt)
+        packet_out.payload = str(pkt)
         # egress_port
         port_md = packet_out.metadata.add()
         port_md.metadata_id = 1
@@ -428,7 +432,7 @@ class FabricTest(P4RuntimeTest):
         inner_vlan_id=None,
     ):
         ingress_port_ = stringify(ingress_port, 2)
-        vlan_valid_ = b"\x01" if vlan_valid else b"\x00"
+        vlan_valid_ = "\x01" if vlan_valid else "\x00"
         vlan_id_ = stringify(vlan_id, 2)
         vlan_id_mask_ = stringify(4095 if vlan_valid else 0, 2)
         new_vlan_id_ = stringify(internal_vlan_id, 2)
@@ -437,9 +441,8 @@ class FabricTest(P4RuntimeTest):
         matches = [
             self.Exact("ig_port", ingress_port_),
             self.Exact("vlan_is_valid", vlan_valid_),
+            self.Ternary("vlan_id", vlan_id_, vlan_id_mask_),
         ]
-        if vlan_id_mask_ != b"\x00\x00":
-            matches.append(self.Ternary("vlan_id", vlan_id_, vlan_id_mask_))
         if inner_vlan_id is not None:
             # Match on inner_vlan, only when explicitly requested
             inner_vlan_id_ = stringify(inner_vlan_id, 2)
@@ -493,10 +496,9 @@ class FabricTest(P4RuntimeTest):
         matches = [
             self.Exact("ig_port", ingress_port_),
             self.Ternary("eth_dst", eth_dstAddr_, eth_mask_),
+            self.Ternary("eth_type", ethertype_, ethertype_mask_),
             self.Exact("ip_eth_type", ip_eth_type),
         ]
-        if ethertype_mask_ != b"\x00\x00":
-            matches.append(self.Ternary("eth_type", ethertype_, ethertype_mask_))
         self.send_request_add_entry_to_action(
             "filtering.fwd_classifier",
             matches,
@@ -515,7 +517,7 @@ class FabricTest(P4RuntimeTest):
     ):
         vlan_id_ = stringify(vlan_id, 2)
         mk = [self.Exact("vlan_id", vlan_id_)]
-        if eth_dstAddr is not None and eth_dstAddr_mask is not None:
+        if eth_dstAddr is not None:
             eth_dstAddr_ = mac_to_binary(eth_dstAddr)
             eth_dstAddr_mask_ = mac_to_binary(eth_dstAddr_mask)
             mk.append(self.Ternary("eth_dst", eth_dstAddr_, eth_dstAddr_mask_))
@@ -913,8 +915,8 @@ class BridgingTest(FabricTest):
             pkt2 = pkt_add_vlan(pkt2, vlan_vid=vlan_id)
             exp_pkt = pkt_add_vlan(exp_pkt, vlan_vid=vlan_id)
 
-        self.send_packet(self.port1, pkt)
-        self.send_packet(self.port2, pkt2)
+        self.send_packet(self.port1, str(pkt))
+        self.send_packet(self.port2, str(pkt2))
         self.verify_each_packet_on_each_port(
             [exp_pkt, exp_pkt2], [self.port2, self.port1]
         )
@@ -922,6 +924,7 @@ class BridgingTest(FabricTest):
 
 class BridgingPriorityTest(FabricTest):
     def runBridgingPriorityTest(self):
+        zero_mac_addr = ":".join(["00"] * 6)
         low_priority = 5
         high_priority = 100
 
@@ -938,7 +941,9 @@ class BridgingPriorityTest(FabricTest):
         self.add_next_output(20, self.port2)
 
         # Add broadcast bridging rule
-        self.add_bridging_entry(vlan_id, None, None, next_id, low_priority)
+        self.add_bridging_entry(
+            vlan_id, zero_mac_addr, zero_mac_addr, next_id, low_priority
+        )
         self.add_next_multicast(next_id, mcast_group_id)
         # Add the multicast group, here we use instance id 1 by default
         replicas = [(1, port) for port in all_ports]
@@ -948,14 +953,14 @@ class BridgingPriorityTest(FabricTest):
         # port 2 only
         pkt = testutils.simple_eth_packet(eth_dst=HOST2_MAC)
         exp_pkt = pkt.copy()
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         self.verify_packet(exp_pkt, self.port2)
         self.verify_no_other_packets()
 
         # Create packet with unknown dst_mac. This packet should be broadcasted
         pkt = testutils.simple_eth_packet(eth_dst="ff:ff:ff:ff:ff:ff")
         exp_pkt = pkt.copy()
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         self.verify_packet(exp_pkt, self.port2)
         self.verify_packet(exp_pkt, self.port3)
         self.verify_no_other_packets()
@@ -981,8 +986,8 @@ class DoubleTaggedBridgingTest(FabricTest):
         exp_pkt = pkt.copy()
         exp_pkt2 = pkt2.copy()
 
-        self.send_packet(self.port1, pkt)
-        self.send_packet(self.port2, pkt2)
+        self.send_packet(self.port1, str(pkt))
+        self.send_packet(self.port2, str(pkt2))
         self.verify_each_packet_on_each_port(
             [exp_pkt, exp_pkt2], [self.port2, self.port1]
         )
@@ -1004,15 +1009,16 @@ class DoubleVlanXConnectTest(FabricTest):
         pkt = pkt_add_vlan(pkt, vlan_vid=vlan_id_outer)
         exp_pkt = pkt.copy()
 
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         self.verify_packet(exp_pkt, self.port2)
 
-        self.send_packet(self.port2, pkt)
+        self.send_packet(self.port2, str(pkt))
         self.verify_packet(exp_pkt, self.port1)
 
 
 class ArpBroadcastTest(FabricTest):
     def runArpBroadcastTest(self, tagged_ports, untagged_ports):
+        zero_mac_addr = ":".join(["00"] * 6)
         vlan_id = 10
         next_id = vlan_id
         mcast_group_id = vlan_id
@@ -1024,7 +1030,7 @@ class ArpBroadcastTest(FabricTest):
             self.set_ingress_port_vlan(port, True, vlan_id, vlan_id)
         for port in untagged_ports:
             self.set_ingress_port_vlan(port, False, 0, vlan_id)
-        self.add_bridging_entry(vlan_id, None, None, next_id)
+        self.add_bridging_entry(vlan_id, zero_mac_addr, zero_mac_addr, next_id)
         self.add_forwarding_acl_copy_to_cpu(eth_type=ETH_TYPE_ARP)
         self.add_next_multicast(next_id, mcast_group_id)
         # Add the multicast group, here we use instance id 1 by default
@@ -1035,8 +1041,9 @@ class ArpBroadcastTest(FabricTest):
 
         for inport in all_ports:
             pkt_to_send = vlan_arp_pkt if inport in tagged_ports else arp_pkt
-            self.send_packet(inport, pkt_to_send)
-            # Pkt should be received on CPU and on all ports, except the ingress one.
+            self.send_packet(inport, str(pkt_to_send))
+            # Pkt should be received on CPU and on all ports, except the
+            # ingress one.
             self.verify_packet_in(exp_pkt=pkt_to_send, exp_in_port=inport)
             verify_tagged_ports = set(tagged_ports)
             verify_tagged_ports.discard(inport)
@@ -1170,7 +1177,7 @@ class IPv4UnicastTest(FabricTest):
         if no_send:
             return
 
-        self.send_packet(ig_port, pkt)
+        self.send_packet(ig_port, str(pkt))
 
         if verify_pkt:
             self.verify_packet(exp_pkt, eg_port)
@@ -1228,7 +1235,7 @@ class IPv4MulticastTest(FabricTest):
         )
 
         # Send packets and verify
-        self.send_packet(in_port, pkt)
+        self.send_packet(in_port, str(pkt))
         for out_port in out_ports:
             self.verify_packet(expect_pkt, out_port)
         self.verify_no_other_packets()
@@ -1331,7 +1338,7 @@ class DoubleVlanTerminationTest(FabricTest):
         if in_tagged and not pkt_is_tagged:
             pkt = pkt_add_vlan(pkt, vlan_vid=in_vlan)
 
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         if verify_pkt:
             self.verify_packet(exp_pkt, self.port2)
         self.verify_no_other_packets()
@@ -1453,7 +1460,7 @@ class DoubleVlanTerminationTest(FabricTest):
             if is_next_hop_spine:
                 exp_pkt = pkt_add_mpls(exp_pkt, label=mpls_label, ttl=DEFAULT_MPLS_TTL)
 
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         if verify_pkt:
             self.verify_packet(exp_pkt, self.port2)
         self.verify_no_other_packets()
@@ -1500,7 +1507,7 @@ class MplsSegmentRoutingTest(FabricTest):
         else:
             exp_pkt = pkt_add_mpls(exp_pkt, label, mpls_ttl - 1)
 
-        self.send_packet(self.port1, pkt)
+        self.send_packet(self.port1, str(pkt))
         self.verify_packet(exp_pkt, self.port2)
 
 
@@ -1519,7 +1526,7 @@ class PacketInTest(FabricTest):
                 self.set_ingress_port_vlan(port, True, vlan_id, vlan_id)
             else:
                 self.set_ingress_port_vlan(port, False, 0, vlan_id)
-            self.send_packet(port, pkt)
+            self.send_packet(port, str(pkt))
             self.verify_packet_in(pkt, port)
         self.verify_no_other_packets()
 
@@ -1984,7 +1991,7 @@ class SpgwReadWriteSymmetryTest(SpgwSimpleTest):
         p4info_params = self.get_obj("actions", action_name).params
         name_list = [""] * len(p4info_params)
         for param in p4info_params:
-            name_list[param.id - 1] = param.name
+            name_list[param.id - 1] = param.name.encode("ascii", "ignore")
 
         params = [
             (name_list[param.param_id - 1], param.value) for param in action.params
@@ -2359,18 +2366,17 @@ class IntTest(IPv4UnicastTest):
             mon_label,
         )
         self.setup_report_mirror_flow(
-            0, INT_REPORT_MIRROR_ID_0, self.recirculate_port_0
+            300, INT_REPORT_MIRROR_ID_0, self.recirculate_port_0
         )
         self.setup_report_mirror_flow(
-            1, INT_REPORT_MIRROR_ID_1, self.recirculate_port_1
+            301, INT_REPORT_MIRROR_ID_1, self.recirculate_port_1
         )
         self.setup_report_mirror_flow(
-            2, INT_REPORT_MIRROR_ID_2, self.recirculate_port_2
+            302, INT_REPORT_MIRROR_ID_2, self.recirculate_port_2
         )
         self.setup_report_mirror_flow(
-            3, INT_REPORT_MIRROR_ID_3, self.recirculate_port_3
+            303, INT_REPORT_MIRROR_ID_3, self.recirculate_port_3
         )
-
         # Set up entries for report packet
         self.setup_port(collector_port, DEFAULT_VLAN)
         # Here we use next-id 101 since `runIPv4UnicastTest` will use 100 by
@@ -2536,16 +2542,16 @@ class SpgwIntTest(SpgwSimpleTest, IntTest):
             mon_label,
         )
         self.setup_report_mirror_flow(
-            0, INT_REPORT_MIRROR_ID_0, self.recirculate_port_0
+            300, INT_REPORT_MIRROR_ID_0, self.recirculate_port_0
         )
         self.setup_report_mirror_flow(
-            1, INT_REPORT_MIRROR_ID_1, self.recirculate_port_1
+            301, INT_REPORT_MIRROR_ID_1, self.recirculate_port_1
         )
         self.setup_report_mirror_flow(
-            2, INT_REPORT_MIRROR_ID_2, self.recirculate_port_2
+            302, INT_REPORT_MIRROR_ID_2, self.recirculate_port_2
         )
         self.setup_report_mirror_flow(
-            3, INT_REPORT_MIRROR_ID_3, self.recirculate_port_3
+            303, INT_REPORT_MIRROR_ID_3, self.recirculate_port_3
         )
 
         # Set up entries for report packet
@@ -2961,7 +2967,7 @@ class PppoeTest(DoubleVlanTerminationTest):
         old_dropped = self.read_byte_count_upstream("dropped", line_id)
         old_control = self.read_pkt_count_upstream("control", line_id)
 
-        self.send_packet(self.port1, pppoed_pkt)
+        self.send_packet(self.port1, str(pppoed_pkt))
         self.verify_packet_in(pppoed_pkt, self.port1)
         self.verify_no_other_packets()
 

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricIntProgrammable.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricIntProgrammable.java
@@ -1,5 +1,5 @@
 // Copyright 2017-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 package org.stratumproject.fabric.tna.behaviour;
 
@@ -82,6 +82,7 @@ public class FabricIntProgrammable extends AbstractFabricHandlerBehavior
             P4InfoConstants.FABRIC_EGRESS_INT_EGRESS_REPORT,
             P4InfoConstants.FABRIC_EGRESS_INT_EGRESS_FLOW_REPORT_FILTER_QUANTIZE_HOP_LATENCY
     );
+    private static final short MIRROR_TYPE_INT_LOCAL_REPORT = 2;
 
     private FlowRuleService flowRuleService;
     private GroupService groupService;
@@ -528,7 +529,8 @@ public class FabricIntProgrammable extends AbstractFabricHandlerBehavior
                 .build();
         final TrafficSelector selector = DefaultTrafficSelector.builder()
                 .matchPi(PiCriterion.builder()
-                        .matchExact(P4InfoConstants.HDR_INT_MIRROR_VALID, 1)
+                        .matchExact(P4InfoConstants.HDR_FABRIC_MD_INT_MIRROR_MIRROR_TYPE,
+                                    MIRROR_TYPE_INT_LOCAL_REPORT)
                         .build())
                 .build();
         return DefaultFlowRule.builder()

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 // Do not modify this file manually, use `make constants` to generate this file.
 
@@ -31,6 +31,8 @@ public final class P4InfoConstants {
             PiMatchFieldId.of("eth_src");
     public static final PiMatchFieldId HDR_ETH_TYPE =
             PiMatchFieldId.of("eth_type");
+    public static final PiMatchFieldId HDR_FABRIC_MD_INT_MIRROR_MIRROR_TYPE =
+            PiMatchFieldId.of("fabric_md.int_mirror.mirror_type");
     public static final PiMatchFieldId HDR_FAR_ID = PiMatchFieldId.of("far_id");
     public static final PiMatchFieldId HDR_GTPU_IS_VALID =
             PiMatchFieldId.of("gtpu_is_valid");
@@ -40,8 +42,6 @@ public final class P4InfoConstants {
             PiMatchFieldId.of("icmp_type");
     public static final PiMatchFieldId HDR_IG_PORT =
             PiMatchFieldId.of("ig_port");
-    public static final PiMatchFieldId HDR_INT_MIRROR_VALID =
-            PiMatchFieldId.of("int_mirror_valid");
     public static final PiMatchFieldId HDR_IP_ETH_TYPE =
             PiMatchFieldId.of("ip_eth_type");
     public static final PiMatchFieldId HDR_IP_PROTO =

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricIntProgrammableTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricIntProgrammableTest.java
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// SPDX-License-Identifier: Apache-2.0
 package org.stratumproject.fabric.tna.behaviour;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -84,6 +84,7 @@ public class FabricIntProgrammableTest {
     private static final int DEFAULT_PRIORITY = 10000;
     private static final IpAddress COLLECTOR_IP = IpAddress.valueOf("10.128.0.1");
     private static final TpPort COLLECTOR_PORT = TpPort.tpPort(32766);
+    private static final short MIRROR_TYPE_INT_LOCAL_REPORT = 2;
     private static final HostLocation COLLECTOR_LOCATION = new HostLocation(LEAF_DEVICE_ID, PortNumber.P0, 0);
     private static final Host COLLECTOR_HOST =
             new DefaultHost(null, null, null, null, COLLECTOR_LOCATION, Sets.newHashSet());
@@ -497,7 +498,8 @@ public class FabricIntProgrammableTest {
                 .build();
         final TrafficSelector selector = DefaultTrafficSelector.builder()
                 .matchPi(PiCriterion.builder()
-                        .matchExact(P4InfoConstants.HDR_INT_MIRROR_VALID, 1)
+                        .matchExact(P4InfoConstants.HDR_FABRIC_MD_INT_MIRROR_MIRROR_TYPE,
+                                    MIRROR_TYPE_INT_LOCAL_REPORT)
                         .build())
                 .build();
         return DefaultFlowRule.builder()


### PR DESCRIPTION
The reason to refactor mirroring in fabric-tna is that we want to provide more types of mirroring like INT drop mirror, simple mirror... and so on.

The way to achieve this is to add an additional metadata field `mirrror_type` to the bridged data between the ingress and egress pipeline so the egress parser can understand the type of packet.