### PR TITLE
Fix pipeconf emitting packet-out metadata with wrong size

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreter.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreter.java
@@ -41,7 +41,11 @@ import static org.onosproject.net.PortNumber.CONTROLLER;
 import static org.onosproject.net.PortNumber.FLOOD;
 import static org.onosproject.net.flow.instructions.Instruction.Type.OUTPUT;
 import static org.onosproject.net.pi.model.PiPacketOperationType.PACKET_OUT;
-import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.*;
+import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.mapAclTreatment;
+import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.mapEgressNextTreatment;
+import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.mapFilteringTreatment;
+import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.mapForwardingTreatment;
+import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter.mapNextTreatment;
 
 /**
  * Interpreter for fabric-tna pipeline.
@@ -49,7 +53,6 @@ import static org.stratumproject.fabric.tna.behaviour.FabricTreatmentInterpreter
 public class FabricInterpreter extends AbstractFabricHandlerBehavior
         implements PiPipelineInterpreter {
 
-    private static final int PORT_BITWIDTH = 9;
     private static final int CPU_LOOPBACK_MODE_DISABLED = 0;
     private static final int CPU_LOOPBACK_MODE_DIRECT = 1;
     private static final int CPU_LOOPBACK_MODE_INGRESS = 2;
@@ -190,19 +193,23 @@ public class FabricInterpreter extends AbstractFabricHandlerBehavior
             ImmutableList.Builder<PiPacketMetadata> builder = ImmutableList.builder();
             builder.add(PiPacketMetadata.builder()
                     .withId(P4InfoConstants.EGRESS_PORT)
-                    .withValue(copyFrom(portNumber).fit(PORT_BITWIDTH))
+                    .withValue(copyFrom(portNumber)
+                            .fit(P4InfoConstants.EGRESS_PORT_BITWIDTH))
                     .build());
             builder.add(PiPacketMetadata.builder()
                     .withId(P4InfoConstants.CPU_LOOPBACK_MODE)
-                    .withValue(copyFrom(CPU_LOOPBACK_MODE_DISABLED))
+                    .withValue(copyFrom(CPU_LOOPBACK_MODE_DISABLED)
+                            .fit(P4InfoConstants.CPU_LOOPBACK_MODE_BITWIDTH))
                     .build());
             builder.add(PiPacketMetadata.builder()
                     .withId(P4InfoConstants.PAD0)
-                    .withValue(copyFrom(0))
+                    .withValue(copyFrom(0)
+                            .fit(P4InfoConstants.PAD0_BITWIDTH))
                     .build());
             builder.add(PiPacketMetadata.builder()
                     .withId(P4InfoConstants.ETHER_TYPE)
-                    .withValue(copyFrom(ETHER_TYPE_PACKET_OUT))
+                    .withValue(copyFrom(ETHER_TYPE_PACKET_OUT)
+                            .fit(P4InfoConstants.ETHER_TYPE_BITWIDTH))
                     .build());
             return builder.build();
         } catch (ImmutableByteSequence.ByteSequenceTrimException e) {

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -261,11 +261,16 @@ public final class P4InfoConstants {
     // Packet Metadata IDs
     public static final PiPacketMetadataId CPU_LOOPBACK_MODE =
             PiPacketMetadataId.of("cpu_loopback_mode");
+    public static final int CPU_LOOPBACK_MODE_BITWIDTH = 2;
     public static final PiPacketMetadataId EGRESS_PORT =
             PiPacketMetadataId.of("egress_port");
+    public static final int EGRESS_PORT_BITWIDTH = 9;
     public static final PiPacketMetadataId ETHER_TYPE =
             PiPacketMetadataId.of("ether_type");
+    public static final int ETHER_TYPE_BITWIDTH = 16;
     public static final PiPacketMetadataId INGRESS_PORT =
             PiPacketMetadataId.of("ingress_port");
+    public static final int INGRESS_PORT_BITWIDTH = 9;
     public static final PiPacketMetadataId PAD0 = PiPacketMetadataId.of("pad0");
+    public static final int PAD0_BITWIDTH = 85;
 }

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreterTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreterTest.java
@@ -229,19 +229,23 @@ public class FabricInterpreterTest {
         ImmutableList.Builder<PiPacketMetadata> builder = ImmutableList.builder();
         builder.add(PiPacketMetadata.builder()
                 .withId(P4InfoConstants.EGRESS_PORT)
-                .withValue(ImmutableByteSequence.copyFrom(outputPort.toLong()).fit(9))
+                .withValue(ImmutableByteSequence.copyFrom(outputPort.toLong())
+                        .fit(P4InfoConstants.EGRESS_PORT_BITWIDTH))
                 .build());
         builder.add(PiPacketMetadata.builder()
                 .withId(P4InfoConstants.CPU_LOOPBACK_MODE)
-                .withValue(ImmutableByteSequence.copyFrom(0))
+                .withValue(ImmutableByteSequence.copyFrom(0)
+                        .fit(P4InfoConstants.CPU_LOOPBACK_MODE_BITWIDTH))
                 .build());
         builder.add(PiPacketMetadata.builder()
                 .withId(P4InfoConstants.ETHER_TYPE)
-                .withValue(ImmutableByteSequence.copyFrom(0xBF01))
+                .withValue(ImmutableByteSequence.copyFrom(0xBF01)
+                        .fit(P4InfoConstants.ETHER_TYPE_BITWIDTH))
                 .build());
         builder.add(PiPacketMetadata.builder()
                 .withId(P4InfoConstants.PAD0)
-                .withValue(ImmutableByteSequence.copyFrom(0))
+                .withValue(ImmutableByteSequence.copyFrom(0)
+                        .fit(P4InfoConstants.PAD0_BITWIDTH))
                 .build());
         PiPacketOperation expectedPktOp = PiPacketOperation.builder()
                 .withType(PiPacketOperationType.PACKET_OUT)


### PR DESCRIPTION
By using auto-generated bit-width constants.

Closes #46.