### PR TITLE
Improve switch_info table

### DIFF
--- a/p4src/include/control/packetio.p4
+++ b/p4src/include/control/packetio.p4
@@ -65,13 +65,13 @@ control PacketIoEgress(inout parsed_headers_t hdr,
                        inout fabric_egress_metadata_t fabric_md,
                        in egress_intrinsic_metadata_t eg_intr_md) {
 
-    action set_cpu_port(PortId_t cpu_port) {
+    action set_switch_info(PortId_t cpu_port) {
         fabric_md.cpu_port = cpu_port;
     }
 
     table switch_info {
         actions = {
-            set_cpu_port;
+            set_switch_info;
             @defaultonly nop;
         }
         default_action = nop;

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -358,7 +358,7 @@ class FabricTest(P4RuntimeTest):
         req = self.get_new_write_request()
         self.push_update_add_entry_to_action(req,
             "FabricEgress.pkt_io_egress.switch_info", None,
-            "FabricEgress.pkt_io_egress.set_cpu_port",
+            "FabricEgress.pkt_io_egress.set_switch_info",
             [("cpu_port", stringify(self.cpu_port, 2))])
         return req, self.write_request(req, store=False)
 

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -159,8 +159,8 @@ public final class P4InfoConstants {
             PiActionId.of("FabricEgress.int_egress.flow_report_filter.quantize");
     public static final PiActionId FABRIC_EGRESS_INT_EGRESS_INIT_METADATA =
             PiActionId.of("FabricEgress.int_egress.init_metadata");
-    public static final PiActionId FABRIC_EGRESS_PKT_IO_EGRESS_SET_CPU_PORT =
-            PiActionId.of("FabricEgress.pkt_io_egress.set_cpu_port");
+    public static final PiActionId FABRIC_EGRESS_PKT_IO_EGRESS_SET_SWITCH_INFO =
+            PiActionId.of("FabricEgress.pkt_io_egress.set_switch_info");
     public static final PiActionId FABRIC_INGRESS_ACL_COPY_TO_CPU =
             PiActionId.of("FabricIngress.acl.copy_to_cpu");
     public static final PiActionId FABRIC_INGRESS_ACL_DROP =

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricPipeliner.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricPipeliner.java
@@ -147,7 +147,7 @@ public class FabricPipeliner extends AbstractFabricHandlerBehavior
     protected void initializePipeline() {
         final PiActionParam param = new PiActionParam(P4InfoConstants.CPU_PORT, capabilities.cpuPort().get());
         final PiAction action = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_EGRESS_PKT_IO_EGRESS_SET_CPU_PORT)
+                .withId(P4InfoConstants.FABRIC_EGRESS_PKT_IO_EGRESS_SET_SWITCH_INFO)
                 .withParameter(param)
                 .build();
         final TrafficTreatment treatment = DefaultTrafficTreatment.builder()


### PR DESCRIPTION
This PR sets `nop` as default action for the `switch_info` table and renames the `set_cpu_port` action to `set_switch_info`. 

Without setting the default action explicitly, `NoAction` will be added to the action list automatically:

```json
        {
          "id" : 16792930,
          "name" : "FabricEgress.pkt_io_egress.set_cpu_port",
          "action_scope" : "TableAndDefault",
          "annotations" : [],
          "data" : [
            {
              "id" : 1,
              "name" : "cpu_port",
              "repeated" : false,
              "mandatory" : true,
              "read_only" : false,
              "annotations" : [],
              "type" : {
                "type" : "bytes",
                "width" : 9
              }
            }
          ]
        },
        {
          "id" : 16819938,
          "name" : "nop",
          "action_scope" : "DefaultOnly",
          "annotations" : [
            {
              "name" : "@defaultonly"
            }
          ],
          "data" : []
        },
        {
          "id" : 16800567,
          "name" : "NoAction",
          "action_scope" : "DefaultOnly",
          "annotations" : [
            {
              "name" : "@defaultonly"
            }
          ],
          "data" : []
        }
```