### PR TITLE
Apply the report filter only when watchlist table hit

### DIFF
--- a/p4src/include/int/int.p4
+++ b/p4src/include/int/int.p4
@@ -278,7 +278,6 @@ control IntEgress (
                     flow_report_filter.apply(hdr, fabric_md, eg_intr_md, eg_prsr_md);
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
To prevent the filter collecting flows other than flows we really watch.