### PR TITLE
Workaround to ignore counters for spgw tests in testvectors

### DIFF
--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -640,7 +640,7 @@ class FabricDefaultVlanPacketInTest(FabricTest):
 @group("spgw")
 class FabricSpgwDownlinkTest(SpgwSimpleTest):
 
-    @tvskip
+    @tvsetup
     @autocleanup
     def doRunTest(self, pkt, tagged1, tagged2, mpls, tc_name):
         self.runDownlinkTest(pkt=pkt, tagged1=tagged1,
@@ -667,7 +667,7 @@ class FabricSpgwDownlinkTest(SpgwSimpleTest):
 @group("spgw")
 class FabricSpgwUplinkTest(SpgwSimpleTest):
 
-    @tvskip
+    @tvsetup
     @autocleanup
     def doRunTest(self, pkt, tagged1, tagged2, mpls):
         self.runUplinkTest(ue_out_pkt=pkt, tagged1=tagged1,

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -1513,18 +1513,22 @@ class SpgwSimpleTest(IPv4UnicastTest):
             ctr_id=ctr_id
         )
 
-        ingress_pdr_pkt_ctr1 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
+        # Workaround to ignore counter verification during testvector generation
+        if not self.generate_tv:
+            ingress_pdr_pkt_ctr1 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
 
         self.runIPv4UnicastTest(pkt=gtp_pkt, dst_ipv4=ue_out_pkt[IP].dst,
                                 next_hop_mac=dst_mac,
                                 prefix_len=32, exp_pkt=exp_pkt,
                                 tagged1=tagged1, tagged2=tagged2, mpls=mpls)
 
-        # Verify the PDR packet counter increased
-        ingress_pdr_pkt_ctr2 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
-        ctr_increase = ingress_pdr_pkt_ctr2 - ingress_pdr_pkt_ctr1
-        if ctr_increase != 1:
-            self.fail("PDR packet counter incremented by %d instead of 1!" % ctr_increase)
+        # Workaround to ignore counter verification during testvector generation
+        if not self.generate_tv:
+            # Verify the PDR packet counter increased
+            ingress_pdr_pkt_ctr2 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
+            ctr_increase = ingress_pdr_pkt_ctr2 - ingress_pdr_pkt_ctr1
+            if ctr_increase != 1:
+                self.fail("PDR packet counter incremented by %d instead of 1!" % ctr_increase)
 
     def runDownlinkTest(self, pkt, tagged1, tagged2, mpls):
 
@@ -1553,18 +1557,22 @@ class SpgwSimpleTest(IPv4UnicastTest):
             ctr_id=ctr_id,
         )
 
-        ingress_pdr_pkt_ctr1 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
+        # Workaround to ignore counter verification during testvector generation
+        if not self.generate_tv:
+            ingress_pdr_pkt_ctr1 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
 
         self.runIPv4UnicastTest(pkt=pkt, dst_ipv4=exp_pkt[IP].dst,
                                 next_hop_mac=dst_mac,
                                 prefix_len=32, exp_pkt=exp_pkt,
                                 tagged1=tagged1, tagged2=tagged2, mpls=mpls)
 
-        # Verify the PDR packet counter increased
-        ingress_pdr_pkt_ctr2 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
-        ctr_increase = ingress_pdr_pkt_ctr2 - ingress_pdr_pkt_ctr1
-        if ctr_increase != 1:
-            self.fail("PDR packet counter incremented by %d instead of 1!" % ctr_increase)
+        # Workaround to ignore counter verification during testvector generation
+        if not self.generate_tv:
+            # Verify the PDR packet counter increased
+            ingress_pdr_pkt_ctr2 = self.read_pkt_count("FabricIngress.spgw_ingress.pdr_counter", ctr_id)
+            ctr_increase = ingress_pdr_pkt_ctr2 - ingress_pdr_pkt_ctr1
+            if ctr_increase != 1:
+                self.fail("PDR packet counter incremented by %d instead of 1!" % ctr_increase)
 
 class IntTest(IPv4UnicastTest):
 


### PR DESCRIPTION
Added a workaround to bypass counter verification for `SpgwDownlinkTest` and `SpgwUplinkTest` when generating TestVectors. After merging this, we can enable these tests on hardware. This is a temporary solution, I will look into providing a permanent fix to this issue.