### PR TITLE
Tie segment routing version to trellis API version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>org.onosproject</groupId>
             <artifactId>segmentrouting-app</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>${trellis.api.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
The snap shot version `3.0.0` does not exist anymore, instead we use a release artifact of the same version as trellis API.