### PR TITLE
[AETHER-538] Explicitily tagged egress ports

### DIFF
--- a/p4src/include/control/next.p4
+++ b/p4src/include/control/next.p4
@@ -267,7 +267,7 @@ control EgressNextControl (inout parsed_headers_t hdr,
     }
 
     @hidden
-    action push_vlan() {
+    action push_outer_vlan() {
         // If VLAN is already valid, we overwrite it with a potentially new VLAN
         // ID, and same CFI, PRI, and eth_type values found in ingress.
         hdr.vlan_tag.setValid();
@@ -295,6 +295,11 @@ control EgressNextControl (inout parsed_headers_t hdr,
      */
     DirectCounter<bit<64>>(CounterType_t.PACKETS_AND_BYTES) egress_vlan_counter;
 
+    action push_vlan() {
+        push_outer_vlan();
+        egress_vlan_counter.count();
+    }
+
     action pop_vlan() {
         hdr.vlan_tag.setInvalid();
         egress_vlan_counter.count();
@@ -306,6 +311,7 @@ control EgressNextControl (inout parsed_headers_t hdr,
             eg_intr_md.egress_port    : exact @name("eg_port");
         }
         actions = {
+            push_vlan;
             pop_vlan;
             @defaultonly nop;
         }
@@ -329,19 +335,16 @@ control EgressNextControl (inout parsed_headers_t hdr,
 #ifdef WITH_DOUBLE_VLAN_TERMINATION
         if (fabric_md.bridged.push_double_vlan) {
             // Double VLAN termination.
-            push_vlan();
+            push_outer_vlan();
             push_inner_vlan();
         } else {
             // If no push double vlan, inner_vlan_tag must be popped
             hdr.inner_vlan_tag.setInvalid();
 #endif // WITH_DOUBLE_VLAN_TERMINATION
-            // Port-based VLAN tagging (by default all
-            // ports are assumed tagged)
+            // Port-based VLAN tagging
             if (!egress_vlan.apply().hit) {
-                // Push VLAN tag if not the default one.
-                if (fabric_md.bridged.vlan_id != DEFAULT_VLAN_ID) {
-                    push_vlan();
-                }
+                // No match no friends - drop the packet
+                eg_dprsr_md.drop_ctl = 1;
             }
 #ifdef WITH_DOUBLE_VLAN_TERMINATION
         }

--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -224,8 +224,8 @@ class FabricIPv4UnicastGroupTest(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
-        self.set_egress_vlan_pop(self.port3, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan(self.port3, vlan_id, False)
 
         pkt_from1 = testutils.simple_tcp_packet(
             eth_src=HOST1_MAC,
@@ -276,8 +276,8 @@ class FabricIPv4UnicastGroupTestAllPortTcpSport(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
-        self.set_egress_vlan_pop(self.port3, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan(self.port3, vlan_id, False)
         # tcpsport_toport list is used to learn the tcp_source_port that
         # causes the packet to be forwarded for each port
         tcpsport_toport = [None, None]
@@ -377,8 +377,8 @@ class FabricIPv4UnicastGroupTestAllPortTcpDport(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
-        self.set_egress_vlan_pop(self.port3, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan(self.port3, vlan_id, False)
         # tcpdport_toport list is used to learn the tcp_destination_port that
         # causes the packet to be forwarded for each port
         tcpdport_toport = [None, None]
@@ -480,8 +480,8 @@ class FabricIPv4UnicastGroupTestAllPortIpSrc(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
-        self.set_egress_vlan_pop(self.port3, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan(self.port3, vlan_id, False)
         # ipsource_toport list is used to learn the ip_src that causes the
         # packet to be forwarded for each port
         ipsource_toport = [None, None]
@@ -580,8 +580,8 @@ class FabricIPv4UnicastGroupTestAllPortIpDst(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
-        self.set_egress_vlan_pop(self.port3, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan(self.port3, vlan_id, False)
         # ipdst_toport list is used to learn the ip_dst that causes the packet
         # to be forwarded for each port
         ipdst_toport = [None, None]
@@ -678,7 +678,7 @@ class FabricIPv4MPLSTest(FabricTest):
         self.add_forwarding_routing_v4_entry(HOST2_IPV4, 24, 400)
         mpls_label = 0xABA
         self.add_next_mpls_routing(400, self.port2, SWITCH_MAC, HOST2_MAC, mpls_label)
-        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan(self.port2, vlan_id, False)
 
         pkt_1to2 = testutils.simple_tcp_packet(
             eth_src=HOST1_MAC,

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -393,11 +393,16 @@ class FabricTest(P4RuntimeTest):
             self.set_ingress_port_vlan(
                 ingress_port=port_id, vlan_id=vlan_id, vlan_valid=True
             )
+            self.set_egress_vlan(
+                egress_port=port_id, vlan_id=vlan_id, push_vlan=True
+            )
         else:
             self.set_ingress_port_vlan(
                 ingress_port=port_id, vlan_valid=False, internal_vlan_id=vlan_id,
             )
-            self.set_egress_vlan_pop(egress_port=port_id, vlan_id=vlan_id)
+            self.set_egress_vlan(
+                egress_port=port_id, vlan_id=vlan_id, push_vlan=False
+            )
 
     @tvcreate("setup/setup_switch_info")
     def setup_switch_info(self):
@@ -455,13 +460,14 @@ class FabricTest(P4RuntimeTest):
             DEFAULT_PRIORITY,
         )
 
-    def set_egress_vlan_pop(self, egress_port, vlan_id):
+    def set_egress_vlan(self, egress_port, vlan_id, push_vlan=False):
         egress_port = stringify(egress_port, 2)
         vlan_id = stringify(vlan_id, 2)
+        action_name = "push_vlan" if push_vlan else "pop_vlan"
         self.send_request_add_entry_to_action(
             "egress_next.egress_vlan",
             [self.Exact("vlan_id", vlan_id), self.Exact("eg_port", egress_port)],
-            "egress_next.pop_vlan",
+            "egress_next." + action_name,
             [],
         )
 
@@ -1032,8 +1038,10 @@ class ArpBroadcastTest(FabricTest):
         # Add the multicast group, here we use instance id 1 by default
         replicas = [(1, port) for port in all_ports]
         self.add_mcast_group(mcast_group_id, replicas)
+        for port in tagged_ports:
+            self.set_egress_vlan(port, vlan_id, True)
         for port in untagged_ports:
-            self.set_egress_vlan_pop(port, vlan_id)
+            self.set_egress_vlan(port, vlan_id, False)
 
         for inport in all_ports:
             pkt_to_send = vlan_arp_pkt if inport in tagged_ports else arp_pkt

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricTreatmentInterpreter.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricTreatmentInterpreter.java
@@ -210,10 +210,15 @@ final class FabricTreatmentInterpreter {
         return null;
     }
 
-
     static PiAction mapEgressNextTreatment(
             TrafficTreatment treatment, PiTableId tableId)
             throws PiInterpreterException {
+        L2ModificationInstruction pushVlan = l2Instruction(treatment, VLAN_PUSH);
+        if (pushVlan != null) {
+            return PiAction.builder()
+                    .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN)
+                    .build();
+        }
         l2InstructionOrFail(treatment, VLAN_POP, tableId);
         return PiAction.builder()
                 .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
@@ -99,4 +99,16 @@ public final class FabricUtils {
         }
         return null;
     }
+
+    public static boolean isL2InterfaceConfiguration(TrafficTreatment treatment) {
+        final Instructions.OutputInstruction output = outputInstruction(treatment);
+        final L2ModificationInstruction vlanPop = l2Instruction(treatment,
+                L2ModificationInstruction.L2SubType.VLAN_POP);
+        // 2 instructions - can be only vlan pop and output to port
+        if (treatment.allInstructions().size() == 2 && vlanPop != null && output != null) {
+            return true;
+        }
+        // 1 instruction - can be only output to port
+        return treatment.allInstructions().size() == 1 && output != null;
+    }
 }

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -137,6 +137,8 @@ public final class P4InfoConstants {
     // Action IDs
     public static final PiActionId FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN =
             PiActionId.of("FabricEgress.egress_next.pop_vlan");
+    public static final PiActionId FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN =
+            PiActionId.of("FabricEgress.egress_next.push_vlan");
     public static final PiActionId FABRIC_EGRESS_INT_EGRESS_DO_REPORT_ENCAP =
             PiActionId.of("FabricEgress.int_egress.do_report_encap");
     public static final PiActionId FABRIC_EGRESS_INT_EGRESS_DO_REPORT_ENCAP_MPLS =

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricNextPipelinerTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricNextPipelinerTest.java
@@ -227,21 +227,45 @@ public class FabricNextPipelinerTest extends FabricPipelinerTest {
                 .withTreatment(treatment)
                 .build();
 
-        // Expected egress VLAN POP flow rule.
+        // Expected egress VLAN_PUSH flow rule.
         PiCriterion egressVlanTableMatch = PiCriterion.builder()
-                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_2.toLong())
+                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_1.toLong())
                 .build();
         TrafficSelector selectorForEgressVlan = DefaultTrafficSelector.builder()
                 .matchPi(egressVlanTableMatch)
                 .matchVlanId(VLAN_100)
                 .build();
         PiAction piActionForEgressVlan = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)
+                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN)
                 .build();
         TrafficTreatment treatmentForEgressVlan = DefaultTrafficTreatment.builder()
                 .piTableAction(piActionForEgressVlan)
                 .build();
-        FlowRule expectedEgressVlanRule = DefaultFlowRule.builder()
+        FlowRule expectedEgressVlanPushRule = DefaultFlowRule.builder()
+                .withSelector(selectorForEgressVlan)
+                .withTreatment(treatmentForEgressVlan)
+                .forTable(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_EGRESS_VLAN)
+                .makePermanent()
+                .withPriority(nextObjective.priority())
+                .forDevice(DEVICE_ID)
+                .fromApp(APP_ID)
+                .build();
+
+        // Expected egress VLAN POP flow rule.
+        egressVlanTableMatch = PiCriterion.builder()
+                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_2.toLong())
+                .build();
+        selectorForEgressVlan = DefaultTrafficSelector.builder()
+                .matchPi(egressVlanTableMatch)
+                .matchVlanId(VLAN_100)
+                .build();
+        piActionForEgressVlan = PiAction.builder()
+                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)
+                .build();
+        treatmentForEgressVlan = DefaultTrafficTreatment.builder()
+                .piTableAction(piActionForEgressVlan)
+                .build();
+        FlowRule expectedEgressVlanPopRule = DefaultFlowRule.builder()
                 .withSelector(selectorForEgressVlan)
                 .withTreatment(treatmentForEgressVlan)
                 .forTable(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_EGRESS_VLAN)
@@ -277,7 +301,8 @@ public class FabricNextPipelinerTest extends FabricPipelinerTest {
         ObjectiveTranslation expectedTranslation = ObjectiveTranslation.builder()
                 .addFlowRule(expectedHashedFlowRule)
                 .addFlowRule(vlanMetaFlowRule)
-                .addFlowRule(expectedEgressVlanRule)
+                .addFlowRule(expectedEgressVlanPushRule)
+                .addFlowRule(expectedEgressVlanPopRule)
                 .addGroup(expectedAllGroup)
                 .build();
 


### PR DESCRIPTION
This commit includes the following changes:
- tagged ports are explicitily matched in the `egress_vlan` table
- `push_outer_vlan` is used by double tagged scenarios
-` push_vlan` becomes an action of the `egress_vlan` table
- if packets do not have hits in the `egress_vlan` table are dropped
- Updates pipeliner and interpreter to handle the new tagged scenarios
- Updates unit tests accordingly

Before this change the pipeline was supporting the untagged ports with flow entries in the `egress_vlan` table. The tagged ports were handled at the egress assuming that the ports are by default tagged: no match means tagged.

We have a new requirement to support dynamic configuration of the interfaces in SR: L2 `MODIFY` of the `NextObjective`. This is necessary to support a dynamic interface change like untagged -> tagged and viceversa. With the old design we had to overload the `Pipeliner` with additional functionalities to remove the entry in the table when it gets an L2 `MODIFY` of a `NextObjective` (imagine the case untagged -> tagged). This approach is not inline with the design philosophy of the `Pipeliner` and honestly it is not very clear why we should remove an entry. This is why we decided to make more explicit and clear the pipeline and keep the `Pipeliner` simple.