### PR TITLE
Revert "[AETHER-538] Explicitily tagged egress ports"

### DIFF
--- a/p4src/include/control/next.p4
+++ b/p4src/include/control/next.p4
@@ -267,7 +267,7 @@ control EgressNextControl (inout parsed_headers_t hdr,
     }
 
     @hidden
-    action push_outer_vlan() {
+    action push_vlan() {
         // If VLAN is already valid, we overwrite it with a potentially new VLAN
         // ID, and same CFI, PRI, and eth_type values found in ingress.
         hdr.vlan_tag.setValid();
@@ -295,18 +295,8 @@ control EgressNextControl (inout parsed_headers_t hdr,
      */
     DirectCounter<bit<64>>(CounterType_t.PACKETS_AND_BYTES) egress_vlan_counter;
 
-    action push_vlan() {
-        push_outer_vlan();
-        egress_vlan_counter.count();
-    }
-
     action pop_vlan() {
         hdr.vlan_tag.setInvalid();
-        egress_vlan_counter.count();
-    }
-
-    action drop() {
-        eg_dprsr_md.drop_ctl = 1;
         egress_vlan_counter.count();
     }
 
@@ -316,11 +306,10 @@ control EgressNextControl (inout parsed_headers_t hdr,
             eg_intr_md.egress_port    : exact @name("eg_port");
         }
         actions = {
-            push_vlan;
             pop_vlan;
-            @defaultonly drop;
+            @defaultonly nop;
         }
-        const default_action = drop();
+        const default_action = nop();
         counters = egress_vlan_counter;
         size = EGRESS_VLAN_TABLE_SIZE;
     }
@@ -340,14 +329,20 @@ control EgressNextControl (inout parsed_headers_t hdr,
 #ifdef WITH_DOUBLE_VLAN_TERMINATION
         if (fabric_md.bridged.push_double_vlan) {
             // Double VLAN termination.
-            push_outer_vlan();
+            push_vlan();
             push_inner_vlan();
         } else {
             // If no push double vlan, inner_vlan_tag must be popped
             hdr.inner_vlan_tag.setInvalid();
 #endif // WITH_DOUBLE_VLAN_TERMINATION
-            // Port-based VLAN tagging; if there is no match drop the packet!
-            egress_vlan.apply();
+            // Port-based VLAN tagging (by default all
+            // ports are assumed tagged)
+            if (!egress_vlan.apply().hit) {
+                // Push VLAN tag if not the default one.
+                if (fabric_md.bridged.vlan_id != DEFAULT_VLAN_ID) {
+                    push_vlan();
+                }
+            }
 #ifdef WITH_DOUBLE_VLAN_TERMINATION
         }
 #endif // WITH_DOUBLE_VLAN_TERMINATION

--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -226,8 +226,8 @@ class FabricIPv4UnicastGroupTest(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan(self.port2, vlan_id, False)
-        self.set_egress_vlan(self.port3, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan_pop(self.port3, vlan_id)
 
         pkt_from1 = testutils.simple_tcp_packet(
             eth_src=HOST1_MAC,
@@ -278,8 +278,8 @@ class FabricIPv4UnicastGroupTestAllPortTcpSport(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan(self.port2, vlan_id, False)
-        self.set_egress_vlan(self.port3, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan_pop(self.port3, vlan_id)
         # tcpsport_toport list is used to learn the tcp_source_port that
         # causes the packet to be forwarded for each port
         tcpsport_toport = [None, None]
@@ -379,8 +379,8 @@ class FabricIPv4UnicastGroupTestAllPortTcpDport(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan(self.port2, vlan_id, False)
-        self.set_egress_vlan(self.port3, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan_pop(self.port3, vlan_id)
         # tcpdport_toport list is used to learn the tcp_destination_port that
         # causes the packet to be forwarded for each port
         tcpdport_toport = [None, None]
@@ -482,8 +482,8 @@ class FabricIPv4UnicastGroupTestAllPortIpSrc(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan(self.port2, vlan_id, False)
-        self.set_egress_vlan(self.port3, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan_pop(self.port3, vlan_id)
         # ipsource_toport list is used to learn the ip_src that causes the
         # packet to be forwarded for each port
         ipsource_toport = [None, None]
@@ -582,8 +582,8 @@ class FabricIPv4UnicastGroupTestAllPortIpDst(FabricTest):
             (self.port3, SWITCH_MAC, HOST3_MAC),
         ]
         self.add_next_routing_group(300, grp_id, mbrs)
-        self.set_egress_vlan(self.port2, vlan_id, False)
-        self.set_egress_vlan(self.port3, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
+        self.set_egress_vlan_pop(self.port3, vlan_id)
         # ipdst_toport list is used to learn the ip_dst that causes the packet
         # to be forwarded for each port
         ipdst_toport = [None, None]
@@ -680,7 +680,7 @@ class FabricIPv4MPLSTest(FabricTest):
         self.add_forwarding_routing_v4_entry(HOST2_IPV4, 24, 400)
         mpls_label = 0xABA
         self.add_next_mpls_routing(400, self.port2, SWITCH_MAC, HOST2_MAC, mpls_label)
-        self.set_egress_vlan(self.port2, vlan_id, False)
+        self.set_egress_vlan_pop(self.port2, vlan_id)
 
         pkt_1to2 = testutils.simple_tcp_packet(
             eth_src=HOST1_MAC,

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricTreatmentInterpreter.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricTreatmentInterpreter.java
@@ -210,15 +210,10 @@ final class FabricTreatmentInterpreter {
         return null;
     }
 
+
     static PiAction mapEgressNextTreatment(
             TrafficTreatment treatment, PiTableId tableId)
             throws PiInterpreterException {
-        L2ModificationInstruction pushVlan = l2Instruction(treatment, VLAN_PUSH);
-        if (pushVlan != null) {
-            return PiAction.builder()
-                    .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN)
-                    .build();
-        }
         l2InstructionOrFail(treatment, VLAN_POP, tableId);
         return PiAction.builder()
                 .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
@@ -99,16 +99,4 @@ public final class FabricUtils {
         }
         return null;
     }
-
-    public static boolean isL2InterfaceConfiguration(TrafficTreatment treatment) {
-        final Instructions.OutputInstruction output = outputInstruction(treatment);
-        final L2ModificationInstruction vlanPop = l2Instruction(treatment,
-                L2ModificationInstruction.L2SubType.VLAN_POP);
-        // 2 instructions - can be only vlan pop and output to port
-        if (treatment.allInstructions().size() == 2 && vlanPop != null && output != null) {
-            return true;
-        }
-        // 1 instruction - can be only output to port
-        return treatment.allInstructions().size() == 1 && output != null;
-    }
 }

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -135,12 +135,8 @@ public final class P4InfoConstants {
     public static final PiCounterId FABRIC_INGRESS_NEXT_NEXT_VLAN_COUNTER =
             PiCounterId.of("FabricIngress.next.next_vlan_counter");
     // Action IDs
-    public static final PiActionId FABRIC_EGRESS_EGRESS_NEXT_DROP =
-            PiActionId.of("FabricEgress.egress_next.drop");
     public static final PiActionId FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN =
             PiActionId.of("FabricEgress.egress_next.pop_vlan");
-    public static final PiActionId FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN =
-            PiActionId.of("FabricEgress.egress_next.push_vlan");
     public static final PiActionId FABRIC_EGRESS_INT_EGRESS_DO_REPORT_ENCAP =
             PiActionId.of("FabricEgress.int_egress.do_report_encap");
     public static final PiActionId FABRIC_EGRESS_INT_EGRESS_DO_REPORT_ENCAP_MPLS =

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/NextObjectiveTranslator.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/NextObjectiveTranslator.java
@@ -237,21 +237,19 @@ class NextObjectiveTranslator
             throws FabricPipelinerException {
         final PortNumber outPort = outputPort(treatment);
         final Instruction popVlanInst = l2Instruction(treatment, VLAN_POP);
-        if (outPort != null) {
+        if (popVlanInst != null && outPort != null) {
             if (strict && treatment.allInstructions().size() > 2) {
                 throw new FabricPipelinerException(
                         "Treatment contains instructions other " +
                                 "than OUTPUT and VLAN_POP, cannot generate " +
                                 "egress rules");
             }
-            if (isL2InterfaceConfiguration(treatment)) {
-                egressVlan(outPort, obj, popVlanInst, resultBuilder);
-            }
+            egressVlanPop(outPort, obj, resultBuilder);
         }
     }
 
-    private void egressVlan(PortNumber outPort, NextObjective obj, Instruction popVlanInst,
-                            ObjectiveTranslation.Builder resultBuilder)
+    private void egressVlanPop(PortNumber outPort, NextObjective obj,
+                               ObjectiveTranslation.Builder resultBuilder)
             throws FabricPipelinerException {
 
         if (obj.meta() == null) {
@@ -264,7 +262,7 @@ class NextObjectiveTranslator
                 obj.meta(), Criterion.Type.VLAN_VID);
         if (vlanIdCriterion == null) {
             throw new FabricPipelinerException(
-                    "Cannot process egress VLAN rule, missing VLAN_VID criterion " +
+                    "Cannot process egress pop VLAN rule, missing VLAN_VID criterion " +
                             "in NextObjective meta",
                     ObjectiveError.BADPARAMS);
         }
@@ -276,16 +274,13 @@ class NextObjectiveTranslator
                 .matchPi(egressVlanTableMatch)
                 .matchVlanId(vlanIdCriterion.vlanId())
                 .build();
-        final TrafficTreatment.Builder treatmentBuilder = DefaultTrafficTreatment.builder();
-        if (popVlanInst == null) {
-            treatmentBuilder.pushVlan();
-        } else {
-            treatmentBuilder.popVlan();
-        }
+        final TrafficTreatment treatment = DefaultTrafficTreatment.builder()
+                .popVlan()
+                .build();
 
         resultBuilder.addFlowRule(flowRule(
                 obj, P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_EGRESS_VLAN,
-                selector, treatmentBuilder.build()));
+                selector, treatment));
     }
 
     private TrafficSelector nextIdSelector(int nextId) {

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricNextPipelinerTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/FabricNextPipelinerTest.java
@@ -227,45 +227,21 @@ public class FabricNextPipelinerTest extends FabricPipelinerTest {
                 .withTreatment(treatment)
                 .build();
 
-        // Expected egress VLAN_PUSH flow rule.
+        // Expected egress VLAN POP flow rule.
         PiCriterion egressVlanTableMatch = PiCriterion.builder()
-                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_1.toLong())
+                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_2.toLong())
                 .build();
         TrafficSelector selectorForEgressVlan = DefaultTrafficSelector.builder()
                 .matchPi(egressVlanTableMatch)
                 .matchVlanId(VLAN_100)
                 .build();
         PiAction piActionForEgressVlan = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_PUSH_VLAN)
+                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)
                 .build();
         TrafficTreatment treatmentForEgressVlan = DefaultTrafficTreatment.builder()
                 .piTableAction(piActionForEgressVlan)
                 .build();
-        FlowRule expectedEgressVlanPushRule = DefaultFlowRule.builder()
-                .withSelector(selectorForEgressVlan)
-                .withTreatment(treatmentForEgressVlan)
-                .forTable(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_EGRESS_VLAN)
-                .makePermanent()
-                .withPriority(nextObjective.priority())
-                .forDevice(DEVICE_ID)
-                .fromApp(APP_ID)
-                .build();
-
-        // Expected egress VLAN POP flow rule.
-        egressVlanTableMatch = PiCriterion.builder()
-                .matchExact(P4InfoConstants.HDR_EG_PORT, PORT_2.toLong())
-                .build();
-        selectorForEgressVlan = DefaultTrafficSelector.builder()
-                .matchPi(egressVlanTableMatch)
-                .matchVlanId(VLAN_100)
-                .build();
-        piActionForEgressVlan = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_POP_VLAN)
-                .build();
-        treatmentForEgressVlan = DefaultTrafficTreatment.builder()
-                .piTableAction(piActionForEgressVlan)
-                .build();
-        FlowRule expectedEgressVlanPopRule = DefaultFlowRule.builder()
+        FlowRule expectedEgressVlanRule = DefaultFlowRule.builder()
                 .withSelector(selectorForEgressVlan)
                 .withTreatment(treatmentForEgressVlan)
                 .forTable(P4InfoConstants.FABRIC_EGRESS_EGRESS_NEXT_EGRESS_VLAN)
@@ -301,8 +277,7 @@ public class FabricNextPipelinerTest extends FabricPipelinerTest {
         ObjectiveTranslation expectedTranslation = ObjectiveTranslation.builder()
                 .addFlowRule(expectedHashedFlowRule)
                 .addFlowRule(vlanMetaFlowRule)
-                .addFlowRule(expectedEgressVlanPushRule)
-                .addFlowRule(expectedEgressVlanPopRule)
+                .addFlowRule(expectedEgressVlanRule)
                 .addGroup(expectedAllGroup)
                 .build();
 


### PR DESCRIPTION
`egress_vlan` table is missing entries to pop VLAN from packets going to spines. Trellis will not insert those entries, we have 2 options:
-  pop by default (instead of drop)
- add a condition in control block `if VLAN == DEFAULT_VLAN (4096) then pop`

For now revert so we can deploy on staging pod.