### PR TITLE
Updated tv/run script to match with tm/run

### DIFF
--- a/ptf/run/tv/run
+++ b/ptf/run/tv/run
@@ -10,7 +10,7 @@ FABRIC_TNA="${FP4TEST_ROOT}"/..
 
 # Tester image
 # Contains PTF and tvutils libraries, as well as P4RT, gNMI, and TV Python bindings
-TESTER_DOCKER_IMG=stratumproject/testvectors:ptf@sha256:32241613c6b0fb56cd9ddb753df31c7355492a1d0d1b0b535efa227f717e44d0
+TESTER_DOCKER_IMG=stratumproject/testvectors:ptf-py3
 SDE_VERSION=${SDE_VERSION:-9.2.0}
 
 if [[ -z "${FABRIC_TNA}" ]]; then


### PR DESCRIPTION
Updated p4src path according to tm/run script. This allows generating TestVectors using correct compiler output based on SDE version.