### PR TITLE
Include profile name when generating test vectors

### DIFF
--- a/ptf/run/tv/Makefile
+++ b/ptf/run/tv/Makefile
@@ -13,6 +13,7 @@ define run_tests
 		--tofino-pipeline-config /p4c-out/pipeline_config.pb.bin \
 		--generate-tv \
 		--loopback \
+		--profile $(1) \
 		$(2)
 endef
 

--- a/ptf/tests/ptf/ptf_runner.py
+++ b/ptf/tests/ptf/ptf_runner.py
@@ -335,7 +335,7 @@ def main():
         "--profile",
         help="The fabric profile",
         type=str,
-        default="fabric",
+        required=True,
         choices=["fabric", "fabric-spgw", "fabric-int", "fabric-spgw-int"],
     )
     args, unknown_args = parser.parse_known_args()


### PR DESCRIPTION
Should include the profile when generating test vectors since the spgw counter byte number can be different between `fabric-spgw` and the `fabric-spgw-int`.