### PR TITLE
Replace PLT_BAREFOOT_TOFINO with PLT_GENERIC_BAREFOOT_TOFINO

### DIFF
--- a/ptf/run/tm/chassis_config.pb.txt
+++ b/ptf/run/tm/chassis_config.pb.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
 description: "Tofino Model"
 chassis {
-  platform: PLT_BAREFOOT_TOFINO
+  platform: PLT_GENERIC_BAREFOOT_TOFINO
   name: "tofino-model"
 }
 nodes {


### PR DESCRIPTION
The enum has been deprecated in 20.12 and will be removed in 21.03.