### PR TITLE
Use const nop default action in qos_classifier table

### DIFF
--- a/p4src/include/control/spgw.p4
+++ b/p4src/include/control/spgw.p4
@@ -167,8 +167,10 @@ control SpgwIngress(
             hdr.ipv4.protocol          : ternary     @name("ip_proto")    ;
        }
        actions = {
-           set_qid();
+           set_qid;
+           @defaultonly nop;
        }
+       const default_action = nop;
     }
     //=============================//
     //===== FAR Tables ======//


### PR DESCRIPTION
When not specified, the compiler generate a non-const `NoAction` as the default one. Somehow this is creating inconsistencies in the ONOS P4RT driver (DefaultEntryMirror), which tries to remove it at each reconciliation cycle. We should fix the  P4RT driver (@pierventre looking into it). In the meantime, we make the `qos_classifier` table use a const `nop` action because that's the intended behavior and it's better to have that explicit in the code.