### PR TITLE
Fix FabricOptimizedFieldDetectorTest

### DIFF
--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -1930,12 +1930,13 @@ class FabricOptimizedFieldDetectorTest(FabricTest):
                 print(diff)
                 self.fail("Read does not match previous write!")
 
-    @tvsetup
     @autocleanup
     def doRunTest(self):
         for table in getattr(self.p4info, "tables"):
             self.handleTable(table)
 
     def runTest(self):
+        if self.generate_tv:
+            return
         print("")
         self.doRunTest()


### PR DESCRIPTION
- Enable the test during CI
- Fix string.split
- Fix integer division

The semantics around integer division change from 2 to 3: `/` is now float division, even if the inputs are int, resulting in runtime errors when function expect an int (`stringify`).
See: https://stackoverflow.com/questions/21316968