### PR TITLE
Fix snippet for Simple ACL forwarding

### DIFF
--- a/p4rt_shell_snippets.md
+++ b/p4rt_shell_snippets.md
@@ -131,7 +131,7 @@ all_te.read(lambda e: print(e))
 
 ### Simple ACL forwarding
 
-To forward packets bidirectionally between port `260` and `268.
+To forward packets bidirectionally between port `260` and `268`:
 
 ```python
 # Configure ports as VLAN untagged by explicitly popping the default VLAN ID 4096 (0xFFE)


### PR DESCRIPTION
Thank @hyojoonkim for reporting this! The `egress_vlan` table drops in case of table miss. We need to install explicit entries for the default VLAN ID 4096.