### PR TITLE
10k scale

### DIFF
--- a/p4src/include/size.p4
+++ b/p4src/include/size.p4
@@ -20,16 +20,22 @@
 #define EGRESS_VLAN_TABLE_SIZE 1024
 #define PORT_VLAN_TABLE_SIZE 1024
 
-// INT
+// Constants for the INT control block.
 #define INT_WATCHLIST_TABLE_SIZE 64
 
-// SPGW
+// Constants for the SPGW control block.
 #define NUM_UES 10240
-#define MAX_UPLINK_RECIRC_RULES 64
-#define MAX_PDR_COUNTERS 2*NUM_UES
-#define NUM_UPLINK_PDRS NUM_UES
-#define NUM_DOWNLINK_PDRS NUM_UES
-#define NUM_FARS 2*NUM_UES
+// We expect between 4 and 8 tunnels per UE.
+#define MAX_GTP_TUNNELS_PER_UE 1
+#define NUM_GTP_TUNNLES (NUM_UES * MAX_GTP_TUNNELS_PER_UE)
+// One counter for down and uplink direction.
+#define MAX_PDR_COUNTERS (2 * NUM_GTP_TUNNLES)
+#define NUM_UPLINK_PDRS NUM_GTP_TUNNLES
+#define NUM_DOWNLINK_PDRS NUM_GTP_TUNNLES
+// One table entry per down and uplink direction.
+#define NUM_FARS (2 * NUM_GTP_TUNNLES)
 #define NUM_SPGW_INTERFACES 64
 #define NUM_QOS_CLASSES 128
-#endif
+#define MAX_UPLINK_RECIRC_RULES 64
+
+#endif  //__TABLE_SIZE__


### PR DESCRIPTION
This PR increases the table sizes to accommodate the 10K UE scale target. The numbers are intentionally on the **conservative** side w.r.t. ASIC resource usage and **are not pushing the limits**. We aim for ~50% TCAM/SRAM/etc utilization per stage and do not want to spread tables over multiple stages yet. This should leave plenty of space for future changes and extensions.

Exact numbers tbd, this is mainly to enable some interesting benchmarks.