### PR TITLE
Fix Makefile resolving individual SDE images with larger one

### DIFF
--- a/.env
+++ b/.env
@@ -9,14 +9,12 @@
 
 # Version of the Barefoot SDE (aka Intel P4 Studio) used to build and test fabric-tna
 SDE_VERSION=${SDE_VERSION:-9.3.1}
-# Docker image with just p4i (can be same as SDE_DOCKER_IMG)
+# Docker image with p4i
 SDE_P4I_DOCKER_IMG=${SDE_DOCKER_IMG:-opennetworking/bf-sde:${SDE_VERSION}-p4i}
-# Docker image with just tofino-model (can be the same as SDE_DOCKER_IMG)
+# Docker image with tofino-model
 SDE_TM_DOCKER_IMG=${SDE_DOCKER_IMG:-opennetworking/bf-sde:${SDE_VERSION}-tm}
-# Docker image with just bf-p4c (can be the same as SDE_DOCKER_IMG)
+# Docker image with bf-p4c
 SDE_P4C_DOCKER_IMG=${SDE_DOCKER_IMG:-opennetworking/bf-sde:${SDE_VERSION}-p4c}
-# Docker image with full installation of the SDE
-SDE_DOCKER_IMG=${SDE_DOCKER_IMG:-opennetworking/bf-sde:${SDE_VERSION}}
 # Used with tofino-model for PTF tests
 STRATUM_DOCKER_IMG=${STRATUM_DOCKER_IMG:-stratumproject/stratum-bfrt:${SDE_VERSION}}
 # Contains PTF and tvutils libraries, as well as P4RT, gNMI, and TV Python bindings


### PR DESCRIPTION
Before this change, the Makefile was resolving the smaller images, e.g., `SDE_P4C_DOCKER_IMG`,  with the larger one `SDE_DOCKER_IMG` (default value):
```
$ make env
SDE_VERSION=9.3.1
SDE_P4I_DOCKER_IMG=opennetworking/bf-sde:9.3.1
SDE_TM_DOCKER_IMG=opennetworking/bf-sde:9.3.1
SDE_P4C_DOCKER_IMG=opennetworking/bf-sde:9.3.1
SDE_DOCKER_IMG=opennetworking/bf-sde:9.3.1
...
```

After this change:
```
$ make env
SDE_VERSION=9.3.1
SDE_P4I_DOCKER_IMG=opennetworking/bf-sde:9.3.1-p4i
SDE_TM_DOCKER_IMG=opennetworking/bf-sde:9.3.1-tm
SDE_P4C_DOCKER_IMG=opennetworking/bf-sde:9.3.1-p4c
...
```

Since all scripts depend on the smaller images `SDE_*_DOCKER_IMG`, we fix the issue by removing  `SDE_DOCKER_IMG`  from `.env`. `SDE_DOCKER_IMG ` can still be used to override the value of all other `SDE_*_DOCKER_IMG` as described in the README.