### PR TITLE
[WIP] Fix flow hasher

### DIFF
--- a/p4src/fabric_tna.p4
+++ b/p4src/fabric_tna.p4
@@ -46,6 +46,7 @@ control FabricIngress (
 
     apply {
         pkt_io_ingress.apply(hdr, fabric_md, ig_intr_md, ig_tm_md, ig_dprsr_md);
+        hasher.apply(hdr, fabric_md);
         filtering.apply(hdr, fabric_md, ig_intr_md);
 #ifdef WITH_SPGW
         if (!fabric_md.skip_forwarding) {
@@ -55,7 +56,6 @@ control FabricIngress (
         if (!fabric_md.skip_forwarding) {
             forwarding.apply(hdr, fabric_md);
         }
-        hasher.apply(hdr, fabric_md);
         acl.apply(hdr, fabric_md, ig_intr_md, ig_dprsr_md, ig_tm_md);
         if (!fabric_md.skip_next) {
             next.apply(hdr, fabric_md, ig_intr_md, ig_tm_md);

--- a/p4src/include/control/hasher.p4
+++ b/p4src/include/control/hasher.p4
@@ -17,14 +17,17 @@ control Hasher(
 
     apply {
 #ifdef WITH_SPGW
-        if (hdr.inner_udp.isValid()) {
-            fabric_md.l4_sport = hdr.inner_udp.sport;
-            fabric_md.l4_dport = hdr.inner_udp.dport;
-        } else if (hdr.inner_tcp.isValid()) {
-            fabric_md.l4_sport = hdr.inner_tcp.sport;
-            fabric_md.l4_dport = hdr.inner_tcp.dport;
-        }
         if (hdr.inner_ipv4.isValid()) {
+            if (hdr.inner_udp.isValid()) {
+                fabric_md.l4_sport = hdr.inner_udp.sport;
+                fabric_md.l4_dport = hdr.inner_udp.dport;
+            } else if (hdr.inner_tcp.isValid()) {
+                fabric_md.l4_sport = hdr.inner_tcp.sport;
+                fabric_md.l4_dport = hdr.inner_tcp.dport;
+            } else {
+                fabric_md.l4_sport = 0;
+                fabric_md.l4_dport = 0;
+            }
             fabric_md.bridged.base.flow_hash = inner_ipv4_hasher.get({
                 hdr.inner_ipv4.src_addr,
                 hdr.inner_ipv4.dst_addr,


### PR DESCRIPTION
We are observing lots of patch change events from the device for a single flow, which means there might be some issue when hashing a packet(5-tuple) every time.

Consider the following cases:
1. GTP traffic: hash the inner header
2. Normal IP traffic: hash 5-tuple (IP src/dst, proto, and l4 ports)
3. non-IP traffic: hash ethernet