### PR TITLE
Fix Register definitions in int.p4

### DIFF
--- a/p4src/include/control/int.p4
+++ b/p4src/include/control/int.p4
@@ -33,9 +33,9 @@ control FlowReportFilter(
     // when the digest of the packet is different than the one of the previous
     // packet of the same flow.
     @hidden
-    Register<flow_report_filter_index_t, bit<16>>(1 << FLOW_REPORT_FILTER_WIDTH, 0) filter1;
+    Register<bit<16>, flow_report_filter_index_t>(1 << FLOW_REPORT_FILTER_WIDTH, 0) filter1;
     @hidden
-    Register<flow_report_filter_index_t, bit<16>>(1 << FLOW_REPORT_FILTER_WIDTH, 0) filter2;
+    Register<bit<16>, flow_report_filter_index_t>(1 << FLOW_REPORT_FILTER_WIDTH, 0) filter2;
 
     // Meaning of the result:
     // 1 digest did NOT change
@@ -92,9 +92,9 @@ control DropReportFilter(
     // We use such filter to reduce the volume of reports that the collector has
     // to ingest.
     @hidden
-    Register<drop_report_filter_index_t, bit<16>>(1 << DROP_REPORT_FILTER_WIDTH, 0) filter1;
+    Register<bit<16>, drop_report_filter_index_t>(1 << DROP_REPORT_FILTER_WIDTH, 0) filter1;
     @hidden
-    Register<drop_report_filter_index_t, bit<16>>(1 << DROP_REPORT_FILTER_WIDTH, 0) filter2;
+    Register<bit<16>, drop_report_filter_index_t>(1 << DROP_REPORT_FILTER_WIDTH, 0) filter2;
 
     // Meaning of the result:
     // 1 digest did NOT change


### PR DESCRIPTION
I was looking through the BA-102 course materials and it seems like the right way to define registers is as follows:
```
Register<data_t, index_t>(num_registers) register;
```
That is, the data type of the stored object goes first and then the data type of the index.

Whereas, here in FlowReportFilter and DropReportFilter it is defined the other way round. This doesn't cause an error because as it turns out the size of the data type and the index type is the same in this case.