### PR TITLE
Add ICMP type to FabricIPv4UnicastGroupTestAllPortIpSrc/Dst test

### DIFF
--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -664,6 +664,7 @@ class FabricIPv4UnicastGroupTestAllPortIpDst(FabricTest):
     def runTest(self):
         self.IPv4UnicastGroupTestAllPortL4DstIp("tcp")
         self.IPv4UnicastGroupTestAllPortL4DstIp("udp")
+        self.IPv4UnicastGroupTestAllPortL4DstIp("icmp")
 
 
 class FabricIPv4MPLSTest(FabricTest):


### PR DESCRIPTION
This PR adds ICMP type to FabricIPv4UnicastGroupTestAllPortIpSrc and FabricIPv4UnicastGroupTestAllPortIpDst test to verify the ECMP group can send ICMP packet to the expect port/next_hop with same IP src or dst