### PR TITLE
Add load_pdr_qos action for uplink_pdrs table

### DIFF
--- a/p4src/include/control/spgw.p4
+++ b/p4src/include/control/spgw.p4
@@ -241,6 +241,7 @@ control SpgwIngress(
         }
         actions = {
             load_pdr;
+            load_pdr_qos;
             @defaultonly uplink_pdr_drop;
         }
         size = NUM_UPLINK_PDRS;


### PR DESCRIPTION
This PR adds the load_pdr_qos action for uplink_pdrs table to make implementation easier of translation and mapping between scheduling priority ranges and Tofino queues for UP4 app.