### PR TITLE
Do not copy packet to CPU if notify_cp is true

### DIFF
--- a/p4src/include/control/spgw.p4
+++ b/p4src/include/control/spgw.p4
@@ -265,7 +265,7 @@ control SpgwIngress(
         fabric_md.skip_forwarding = drop;
         fabric_md.skip_next = drop;
         // TODO: Send notification to 3GPP/SPGW control plane
-        fabric_md.spgw.notify_spgwc = notify_cp;
+        fabric_md.bridged.spgw.notify_spgwc = notify_cp;
         fabric_md.bridged.spgw.needs_gtpu_encap = false;
         fabric_md.bridged.spgw.skip_egress_pdr_ctr = false;
     }
@@ -282,7 +282,7 @@ control SpgwIngress(
         fabric_md.skip_forwarding = drop;
         fabric_md.skip_next = drop;
         // TODO: Send notification to 3GPP/SPGW control plane
-        fabric_md.spgw.notify_spgwc = notify_cp;
+        fabric_md.bridged.spgw.notify_spgwc = notify_cp;
         // GTP tunnel attributes
         fabric_md.bridged.spgw.needs_gtpu_encap = true;
         fabric_md.bridged.spgw.gtpu_teid = teid;

--- a/p4src/include/header.p4
+++ b/p4src/include/header.p4
@@ -132,10 +132,11 @@ header gtpu_t {
 // See bridged_metadata_base_t
 struct spgw_bridged_metadata_t {
     bit<16>         ipv4_len_for_encap;
-    @padding bit<5> _pad0;
+    @padding bit<4> _pad0;
     bool            needs_gtpu_encap;
     bool            skip_spgw;
     bool            skip_egress_pdr_ctr;
+    bool            notify_spgwc;
     teid_t          gtpu_teid;
     ipv4_addr_t     gtpu_tunnel_sip;
     ipv4_addr_t     gtpu_tunnel_dip;
@@ -145,7 +146,6 @@ struct spgw_bridged_metadata_t {
 
 struct spgw_ingress_metadata_t {
     bool               needs_gtpu_decap;
-    bool               notify_spgwc;
     far_id_t           far_id;
     SpgwInterface      src_iface;
 }


### PR DESCRIPTION
When notify_cp is true, the switch should send a packet to 3GPP control
plane(SPGW control plane) instead of SDN control plane(ONOS).

Currently we store this flag to notify_spgwc metadata for future use.
And will have another pull request that implements this feature