### PR TITLE
Simplify the hasher control block

### DIFF
--- a/p4src/include/control/hasher.p4
+++ b/p4src/include/control/hasher.p4
@@ -4,60 +4,45 @@
 #include "../define.p4"
 #include "../header.p4"
 
-// Used for ECMP hashing.
-struct gtp_flow_t {
-    bit<32>   ipv4_src;
-    bit<32>   ipv4_dst;
-    teid_t    gtpu_teid;
-}
-
 control Hasher(
     in parsed_headers_t hdr,
     inout fabric_ingress_metadata_t fabric_md) {
 
     Hash<flow_hash_t>(HashAlgorithm_t.CRC32) ip_hasher;
     Hash<flow_hash_t>(HashAlgorithm_t.CRC32) gtp_flow_hasher;
+    Hash<flow_hash_t>(HashAlgorithm_t.CRC32) encap_gtp_flow_hasher;
     Hash<flow_hash_t>(HashAlgorithm_t.CRC32) non_ip_hasher;
 
     apply {
-        if (fabric_md.lkp.is_ipv4) {
-            gtp_flow_t to_hash = {0, 0, 0};
-            bool calc_gtp_hash = false;
-
-            // we always need to calculate hash from the inner IPv4 header for the INT reporter.
-            fabric_md.bridged.base.inner_hash = ip_hasher.get({
-                fabric_md.lkp.ipv4_src,
-                fabric_md.lkp.ipv4_dst,
-                fabric_md.lkp.ip_proto,
-                fabric_md.lkp.l4_sport,
-                fabric_md.lkp.l4_dport
-            });
-
-            // use inner hash by default
-            fabric_md.ecmp_hash = fabric_md.bridged.base.inner_hash;
-
-            // if an outer GTP header exists, use it to perform GTP-aware ECMP
-            if (hdr.gtpu.isValid()) {
-                to_hash.ipv4_src = hdr.ipv4.src_addr;
-                to_hash.ipv4_dst = hdr.ipv4.dst_addr;
-                to_hash.gtpu_teid = hdr.gtpu.teid;
-                calc_gtp_hash = true;
-            }
+        // we always need to calculate hash from the inner IPv4 header for the INT reporter.
+        fabric_md.bridged.base.inner_hash = ip_hasher.get({
+            fabric_md.lkp.ipv4_src,
+            fabric_md.lkp.ipv4_dst,
+            fabric_md.lkp.ip_proto,
+            fabric_md.lkp.l4_sport,
+            fabric_md.lkp.l4_dport
+        });
 
 #ifdef WITH_SPGW
-            // enable GTP-aware ECMP for downlink packets.
-            if (fabric_md.bridged.spgw.needs_gtpu_encap) {
-                to_hash.ipv4_src = fabric_md.bridged.spgw.gtpu_tunnel_sip;
-                to_hash.ipv4_dst = fabric_md.bridged.spgw.gtpu_tunnel_dip;
-                to_hash.gtpu_teid = fabric_md.bridged.spgw.gtpu_teid;
-                calc_gtp_hash = true;
-            }
+        // enable GTP-aware ECMP for downlink packets.
+        if (fabric_md.bridged.spgw.needs_gtpu_encap) {
+            fabric_md.ecmp_hash = encap_gtp_flow_hasher.get({
+                fabric_md.bridged.spgw.gtpu_tunnel_sip,
+                fabric_md.bridged.spgw.gtpu_tunnel_dip,
+                fabric_md.bridged.spgw.gtpu_teid
+            });
+        } else
 #endif // WITH_SPGW
-
-            if (calc_gtp_hash) {
-                fabric_md.ecmp_hash = gtp_flow_hasher.get(to_hash);
-            }
-
+        // if an outer GTP header exists, use it to perform GTP-aware ECMP
+        if (hdr.gtpu.isValid()) {
+            fabric_md.ecmp_hash = gtp_flow_hasher.get({
+                hdr.ipv4.src_addr,
+                hdr.ipv4.dst_addr,
+                hdr.gtpu.teid
+            });
+        } else if (fabric_md.lkp.is_ipv4) {
+            // use inner hash by default
+            fabric_md.ecmp_hash = fabric_md.bridged.base.inner_hash;
         }
         // FIXME: remove ipv6 support or test it
         //  https://github.com/stratum/fabric-tna/pull/227
@@ -72,7 +57,10 @@ control Hasher(
         // }
         else {
             // Not an IP packet
-            fabric_md.bridged.base.inner_hash = non_ip_hasher.get({
+            // Set inner hash to zero since we will never process this packet through
+            // the INT pipeline.
+            fabric_md.bridged.base.inner_hash = 0;
+            fabric_md.ecmp_hash = non_ip_hasher.get({
                 hdr.ethernet.dst_addr,
                 hdr.ethernet.src_addr,
                 hdr.eth_type.value


### PR DESCRIPTION
When compiling the change from #245, the compiler return an error.

To solve the issue, we can try to simplify the hasher control block implementation

The original logic is:

```
if is ipv4 {
    inner_hash = hash from ACL lookup
    ecmp_hash = inner_hash
    if gtpu is valid {
        set up to hash tuple with outer IP and TEID from gtpu
        set calc_gtp_hash flag to true
    }
    if we need to encap later in the egress pipeline {
        set up to hash tuple with tunnel IP (will be outer IP) and TEID of the tunnel
        set calc_gtp_hash flag to true
    }
    if calc_gtp_hash flag is true {
        override the ecmp hash to the one from gtom gtp hash tuple
    }
}
```

We can notice that the two inner `if` condition (check gtp header and encap flag) is actually covering the first `if` (ipv4 is valid)
 - If the GTPU header is valid, means there must be an IP/UDP/GTPU header
 - If the pipeline need to encap later, means it hits PDR and FAR tables, which already check IPv4 header

So we can assume there are four(4) cases for the ecmp hash, and we initialize the inner hash with the ACL lookup fields

 - Need to encap later -> use tunnel information for ecmp hash
 - GTPU header is valid -> use TEID from GTPU header and outer IP
 - Is IPv4 -> ecmp hash will be same as the inner has (from ACL lookup)
 - Else case -> user ethernet header for ecmp hash and set inner hash to zero
 
 This PR also reduce the compile time from 8mins to 1min
