### PR TITLE
Fix missing packet-in for the INT reports when running PTF tests in loopback mode

### DIFF
--- a/p4src/include/header.p4
+++ b/p4src/include/header.p4
@@ -354,7 +354,8 @@ struct fabric_egress_metadata_t {
 }
 
 header fake_ethernet_t {
-    bit<96> offset;
+    @padding bit<48> _pad0;
+    @padding bit<48> _pad1;
     bit<16> ether_type;
 }
 

--- a/p4src/include/parser.p4
+++ b/p4src/include/parser.p4
@@ -325,8 +325,6 @@ parser FabricEgressParser (packet_in packet,
 
     state set_cpu_loopback_egress {
         hdr.fake_ethernet.setValid();
-        // We need to zero-initialize. Otherwise, we get garbage in the output packet.
-        hdr.fake_ethernet.offset = 0;
         hdr.fake_ethernet.ether_type = ETHERTYPE_CPU_LOOPBACK_EGRESS;
         packet.advance(ETH_HDR_BYTES * 8);
         transition parse_ethernet;

--- a/ptf/tests/ptf/fabric.ptf/test.py
+++ b/ptf/tests/ptf/fabric.ptf/test.py
@@ -2676,6 +2676,8 @@ class FabricIntLocalReportLoopbackModeTest(IntTest):
             Ether(type=ETH_TYPE_CPU_LOOPBACK_EGRESS, src=ZERO_MAC, dst=ZERO_MAC) / exp_int_report_pkt
         )
         exp_int_report_pkt_masked = Mask(exp_int_report_pkt_loopback)
+        exp_int_report_pkt_masked.set_do_not_care_scapy(Ether, "src")
+        exp_int_report_pkt_masked.set_do_not_care_scapy(Ether, "dst")
         # IPv4 identification
         # The reason we also ignore IP checksum is because the `id` field is
         # random.


### PR DESCRIPTION
Closes #178. 

