### PR TITLE
Suppress shellcheck errors on codecov.sh

### DIFF
--- a/.jenkins/codecov.sh
+++ b/.jenkins/codecov.sh
@@ -72,7 +72,9 @@ branch="$VCS_BRANCH_NAME"
 pr="$VCS_PULL_REQUEST"
 slug="$VCS_SLUG"
 tag="$VCS_TAG"
+# shellcheck disable=SC2153
 build_url="$CI_BUILD_URL"
+# shellcheck disable=SC2153
 build="$CI_BUILD_ID"
 job="$CI_JOB_ID"
 


### PR DESCRIPTION
CI for #251 is failing because of these errors. I'm not sure what's the trigger, we weren't seeing them before.