### PR TITLE
Handle malformed PacketIn metadata more defensively

### DIFF
--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreterTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricInterpreterTest.java
@@ -234,7 +234,8 @@ public class FabricInterpreterTest {
         PortNumber inputPort = PortNumber.portNumber(1);
         PiPacketMetadata pktInMetadata = PiPacketMetadata.builder()
                 .withId(P4InfoConstants.INGRESS_PORT)
-                .withValue(ImmutableByteSequence.copyFrom(inputPort.toLong()).fit(9))
+                .withValue(ImmutableByteSequence.copyFrom(inputPort.toLong())
+                        .fit(P4InfoConstants.INGRESS_PORT_BITWIDTH))
                 .build();
         Ethernet packet = new Ethernet();
         packet.setDestinationMACAddress(SRC_MAC);
@@ -253,6 +254,37 @@ public class FabricInterpreterTest {
         InboundPacket expectedInboundPacket
                 = new DefaultInboundPacket(receiveFrom, packet, ByteBuffer.wrap(packet.serialize()));
 
+        assertEquals(result.receivedFrom(), expectedInboundPacket.receivedFrom());
+        assertEquals(result.parsed(), expectedInboundPacket.parsed());
+        assertEquals(result.cookie(), expectedInboundPacket.cookie());
+
+        assertEquals(result.unparsed(), expectedInboundPacket.unparsed());
+    }
+
+    @Test
+    public void testMapInboundPacketWithShortMetadata() throws ImmutableByteSequence.ByteSequenceTrimException,
+            PiPipelineInterpreter.PiInterpreterException {
+        PortNumber inputPort = PortNumber.portNumber(1);
+        PiPacketMetadata pktInMetadata = PiPacketMetadata.builder()
+                .withId(P4InfoConstants.INGRESS_PORT)
+                .withValue(ImmutableByteSequence.copyFrom(inputPort.toLong()).fit(8))  // deliberately smaller
+                .build();
+        Ethernet packet = new Ethernet();
+        packet.setDestinationMACAddress(SRC_MAC);
+        packet.setSourceMACAddress(DST_MAC);
+        packet.setEtherType((short) 0xBA00);
+        packet.setPayload(new Data());
+
+        PiPacketOperation pktInOp = PiPacketOperation.builder()
+                .withMetadata(pktInMetadata)
+                .withData(ImmutableByteSequence.copyFrom(packet.serialize()))
+                .withType(PiPacketOperationType.PACKET_IN)
+                .build();
+        InboundPacket result = interpreter.mapInboundPacket(pktInOp, DEVICE_ID);
+
+        ConnectPoint receiveFrom = new ConnectPoint(DEVICE_ID, inputPort);
+        InboundPacket expectedInboundPacket
+                = new DefaultInboundPacket(receiveFrom, packet, ByteBuffer.wrap(packet.serialize()));
 
         assertEquals(result.receivedFrom(), expectedInboundPacket.receivedFrom());
         assertEquals(result.parsed(), expectedInboundPacket.parsed());


### PR DESCRIPTION
This change ensures metadata byte strings have the required size before parsing them as shorts.

First order effect: no more uncaught exception spam in ONOS logs when Stratum delivers malformed `PacketIn`s:
```
tost    | 19:46:00.822 ERROR [P4RuntimePacketProvider] Uncaught exception on onos-p4rt-packet-worker-1834
tost    | java.nio.BufferUnderflowException
tost    | 	at java.base/java.nio.Buffer.nextGetIndex(Buffer.java:650)
tost    | 	at java.base/java.nio.HeapByteBuffer.getShort(HeapByteBuffer.java:348)
tost    | 	at org.stratumproject.fabric.tna.behaviour.FabricInterpreter.mapInboundPacket(FabricInterpreter.java:277)
tost    | 	at org.onosproject.provider.p4runtime.packet.impl.P4RuntimePacketProvider.handleP4RuntimeEvent(P4RuntimePacketProvider.java:237)
tost    | 	at org.onosproject.provider.p4runtime.packet.impl.P4RuntimePacketProvider$InternalPacketListener.lambda$event$0(P4RuntimePacketProvider.java:272)
tost    | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
tost    | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
tost    | 	at java.base/java.lang.Thread.run(Thread.java:834)
[... repeats]
```

Side effect: we transparently support canon byte strings for PacketIns