### PR TITLE
Allow setting non-zero default QFI

### DIFF
--- a/p4src/include/control/spgw.p4
+++ b/p4src/include/control/spgw.p4
@@ -415,8 +415,10 @@ control SpgwEgress(
 #endif // WITH_INT
     }
 
-    // Do GTP-U encap with PDU Session Container extension for 5G NG-RAN.
-    action gtpu_with_psc() {
+    // Do GTP-U encap with PDU Session Container extension for 5G NG-RAN with
+    // configurable QFI.
+    // TODO: allow setting different QFIs in ingress
+    action gtpu_with_psc(bit<6> qfi) {
         _encap_common();
         hdr.outer_ipv4.total_len = hdr.ipv4.total_len
                 + IPV4_HDR_BYTES + UDP_HDR_BYTES + GTPU_HDR_BYTES
@@ -429,6 +431,7 @@ control SpgwEgress(
         hdr.outer_gtpu.ex_flag = 1;
         hdr.outer_gtpu_options.setValid();
         hdr.outer_gtpu_ext_psc.setValid();
+        hdr.outer_gtpu_ext_psc.qfi = qfi;
 #ifdef WITH_INT
         fabric_md.int_mirror_md.gtpu_presence = GtpuPresence.GTPU_WITH_PSC;
 #endif // WITH_INT

--- a/p4src/include/parser.p4
+++ b/p4src/include/parser.p4
@@ -376,7 +376,7 @@ parser FabricEgressParser (packet_in packet,
         hdr.outer_gtpu_ext_psc.spare0    = 0;
         hdr.outer_gtpu_ext_psc.ppp       = 0;
         hdr.outer_gtpu_ext_psc.rqi       = 0;
-        hdr.outer_gtpu_ext_psc.qfi       = 0; // TODO: allow setting in ingress
+        // hdr.outer_gtpu_ext_psc.qfi    = update later
         hdr.outer_gtpu_ext_psc.next_ext  = GTPU_NEXT_EXT_NONE;
 #endif // WITH_SPGW
 #ifdef WITH_INT

--- a/ptf/tests/ptf/fabric_test.py
+++ b/ptf/tests/ptf/fabric_test.py
@@ -2072,9 +2072,10 @@ class SpgwSimpleTest(IPv4UnicastTest):
             tunnel_dst_addr=s1u_enb_addr,
         )
 
-    def enable_encap_with_psc(self):
+    def enable_encap_with_psc(self, qfi=0):
         self.send_request_add_entry_to_action(
-            "FabricEgress.spgw.gtpu_encap", None, "FabricEgress.spgw.gtpu_with_psc", [],
+            "FabricEgress.spgw.gtpu_encap", None, "FabricEgress.spgw.gtpu_with_psc",
+            [('qfi', stringify(qfi, 1))],
         )
 
     def reset_pdr_counters(self, ctr_idx):

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -281,6 +281,7 @@ public final class P4InfoConstants {
             PiActionParamId.of("port_num");
     public static final PiActionParamId PORT_TYPE =
             PiActionParamId.of("port_type");
+    public static final PiActionParamId QFI = PiActionParamId.of("qfi");
     public static final PiActionParamId QID = PiActionParamId.of("qid");
     public static final PiActionParamId SMAC = PiActionParamId.of("smac");
     public static final PiActionParamId SRC_IFACE =


### PR DESCRIPTION
Some gNBs might drop downlink packets unless they have a specific QFI. The long-term plan is to be PFCP-compliant, and expose the ability to set QFIs for different flows. For now, we allow a configurable default QFI for all downlink traffic. This change is required by https://github.com/omec-project/up4/pull/147.