### PR TITLE
[SDFAB-293] Fix UPF call setup performance degradation

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
@@ -92,6 +92,12 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
         if (!super.setupBehaviour(opName)) {
             return false;
         }
+
+        if (!computeHardwareResourceSizes()) {
+            // error message will be printed by computeHardwareResourceSizes()
+            return false;
+        }
+
         flowRuleService = handler().get(FlowRuleService.class);
         packetService = handler().get(PacketService.class);
         fabricUpfStore = handler().get(DistributedFabricUpfStore.class);
@@ -116,10 +122,6 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
     @Override
     public boolean init() {
         if (setupBehaviour("init()")) {
-            if (!computeHardwareResourceSizes()) {
-                // error message will be printed by computeHardwareResourceSizes()
-                return false;
-            }
             log.info("UpfProgrammable initialized for appId {} and deviceId {}", appId, deviceId);
             return true;
         }


### PR DESCRIPTION
It has been observed that calling `setupBehavior` and `computeHardwareResources` for each flow introduce a not negligible delay and these operations were not performed before the refactoring for each flow.

There is no need to call the setup steps of `setupBehavior` each time but should be called only the very first time. This patch makes `setupBehavior` more smart. 

Then, looking at the performance with the profiler, we noticed that `computeHwResources` is the most expensive operation we have introduced recently - it does not seem necessary to compute the hw resources each time. With this patch we compute the hw resources/limits only at the behavior init.