### PR TITLE
Fix for new Stratum release

### DIFF
--- a/ptf/run/tm/chassis_config.pb.txt
+++ b/ptf/run/tm/chassis_config.pb.txt
@@ -12,7 +12,7 @@ nodes {
   index: 1
 }
 singleton_ports {
-  id: 0
+  id: 1
   name: "veth1"
   slot: 1
   port: 1
@@ -24,7 +24,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 1
+  id: 2
   name: "veth3"
   slot: 1
   port: 2
@@ -36,7 +36,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 2
+  id: 3
   name: "veth5"
   slot: 1
   port: 3
@@ -48,7 +48,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 3
+  id: 4
   name: "veth7"
   slot: 1
   port: 4
@@ -60,7 +60,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 4
+  id: 5
   name: "veth9"
   slot: 1
   port: 5
@@ -72,7 +72,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 5
+  id: 6
   name: "veth11"
   slot: 1
   port: 6
@@ -84,7 +84,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 6
+  id: 7
   name: "veth13"
   slot: 1
   port: 7
@@ -96,7 +96,7 @@ singleton_ports {
   node: 1
 }
 singleton_ports {
-  id: 7
+  id: 8
   name: "veth15"
   slot: 1
   port: 8

--- a/ptf/run/tm/stratum_entrypoint.sh
+++ b/ptf/run/tm/stratum_entrypoint.sh
@@ -25,7 +25,7 @@ fi
 ${stratumBin} \
     -bf_sde_install=/usr \
     -bf_switchd_background=true \
-    -bf_switchd_cfg=/usr/share/stratum/tofino_skip_p4.conf \
+    -bf_switchd_cfg=/usr/share/stratum/tofino_skip_p4_no_bsp.conf \
     -chassis_config_file="${DIR}"/chassis_config.pb.txt \
     -external_stratum_urls=0.0.0.0:28000 \
     -forwarding_pipeline_configs_file=/dev/null \


### PR DESCRIPTION
This PR includes two changes:

Previously, we are using the `tofino_skip_p4.conf` file to start Stratum, which tells the bf_switchd to use a non-exist platform library file when it initialized. According to Barefoot, the bf_switchd will switch to "MODEL" mode if the platform library file does not exist.
Recently, we include the default platform library to the Stratum container image, and it will try to use it when running. The new Stratum container image also misses some dependency required by the platform library, this causes Stratum to fail to start. (stratum/stratum#768 fixes the dependency issue)
However, we still need to tell bf_switchd to switch to the MODEL mode. After checking the bf_switchd driver code, we realized that the bf_switchd will also switch to MODEL mode if the `port_map.json` file is not present.
We can use `tofino_skip_p4_no_bsp.conf` as the bf_switchd config file to start the Stratum because the port_map.json file described in the config does not exist by default in the Stratum container.

Another change in this PR is to change the singleton port ID in the chassis config file to a non-zero value. See stratum/stratum#761 for more detail about the singleton port ID change.