### PR TITLE
Put ports into promiscuous mode by default for linerate tests

### DIFF
--- a/ptf/tests/common/trex_test.py
+++ b/ptf/tests/common/trex_test.py
@@ -16,6 +16,9 @@ class TRexTest(P4RuntimeTest):
         self.trex_client.acquire()
         self.trex_client.reset()  # Resets configs from all ports
         self.trex_client.clear_stats()  # Clear status from all ports
+        # Put all ports to promiscuous mode, otherwise they will drop all
+        # incoming packets if the destination mac is not the port mac address.
+        self.trex_client.set_port_attr(self.trex_client.get_all_ports(), promiscuous=True)
 
     def tearDown(self):
         print("Tearing down STLClient...")

--- a/ptf/tests/linerate/int_single_flow.py
+++ b/ptf/tests/linerate/int_single_flow.py
@@ -50,12 +50,6 @@ class IntSingleFlow(TRexTest, IntTest):
         stream = STLStream(packet=STLPktBuilder(pkt=pkt, vm=[]), mode=STLTXCont())
         self.trex_client.add_streams(stream, ports=SENDER_PORTS)
 
-        # Put RX ports to promiscuous mode, otherwise it will drop all packets if the
-        # destination mac is not the port mac address.
-        self.trex_client.set_port_attr(
-            INT_COLLECTOR_PORTS + RECEIVER_PORTS, promiscuous=True
-        )
-
         # Capture INT packets
         self.trex_client.set_service_mode(ports=INT_COLLECTOR_PORTS, enabled=True)
         capture = self.trex_client.start_capture(


### PR DESCRIPTION
Pretty much all tests will need this, unless we want tests to randomly break because we swapped a NIC.