### PR TITLE
Move `SlicingTest` from slicing.py to fabric_test.py

### DIFF
--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -278,6 +278,10 @@ PORT_TYPE_INTERNAL = b"\x03"
 DEFAULT_SLICE_ID = 0
 DEFAULT_TC = 0
 
+COLOR_GREEN = 0
+COLOR_YELLOW = 1
+COLOR_RED = 3
+
 # Implements helper function for SCTP as PTF does not provide one.
 def simple_sctp_packet(
     pktlen=100,
@@ -4077,3 +4081,56 @@ class PppoeTest(DoubleVlanTerminationTest):
             self.assertGreaterEqual(new_tx_count, old_tx_count + len(pkt))
         else:
             self.assertEqual(new_tx_count, old_tx_count)
+
+
+class SlicingTest(FabricTest):
+    """Mixin class with methods to manipulate QoS entities
+    """
+
+    def slice_tc_index(self, slice_id, tc):
+        return (slice_id << 4) + tc
+
+    def add_slice_tc_classifier_entry(self, slice_id, tc, **ftuple):
+        return self.send_request_add_entry_to_action(
+            "FabricIngress.slice_tc_classifier.classifier",
+            self.build_acl_matches(**ftuple),
+            "FabricIngress.slice_tc_classifier.set_slice_id_tc",
+            [("slice_id", stringify(slice_id, 1)), ("tc", stringify(tc, 1))],
+            DEFAULT_PRIORITY,
+        )
+
+    def configure_slice_tc_meter(self, slice_id, tc, cir, cburst, pir, pburst):
+        return self.write_indirect_meter(
+            m_name="FabricIngress.qos.slice_tc_meter",
+            m_index=self.slice_tc_index(slice_id, tc),
+            cir=cir,
+            cburst=cburst,
+            pir=pir,
+            pburst=pburst,
+        )
+
+    def add_queue_entry(self, slice_id, tc, qid=None, color=None):
+        matches = [
+            self.Exact("slice_id", stringify(slice_id, 1)),
+            self.Exact("tc", stringify(tc, 1)),
+        ]
+        if color is not None:
+            matches.append(
+                self.Ternary("color", stringify(color, 1), stringify(0x3, 1))
+            )
+        if qid is not None:
+            action = "FabricIngress.qos.set_queue"
+            action_params = [("qid", stringify(qid, 1))]
+        else:
+            action = "FabricIngress.qos.meter_drop"
+            action_params = []
+        return self.send_request_add_entry_to_action(
+            "FabricIngress.qos.queues",
+            matches,
+            action,
+            action_params,
+            DEFAULT_PRIORITY,
+        )
+
+    def enable_policing(self, slice_id, tc, color=COLOR_RED):
+        return self.add_queue_entry(slice_id, tc, None, color=color)

--- a/ptf/tests/unary/slicing.py
+++ b/ptf/tests/unary/slicing.py
@@ -5,64 +5,6 @@ from base_test import autocleanup, tvsetup
 from fabric_test import *  # noqa
 from scapy.layers.inet import IP
 
-COLOR_GREEN = 0
-COLOR_YELLOW = 1
-COLOR_RED = 3
-
-
-class SlicingTest(FabricTest):
-    """Mixin class with methods to manipulate QoS entities
-    """
-
-    def slice_tc_index(self, slice_id, tc):
-        return (slice_id << 4) + tc
-
-    def add_slice_tc_classifier_entry(self, slice_id, tc, **ftuple):
-        self.send_request_add_entry_to_action(
-            "FabricIngress.slice_tc_classifier.classifier",
-            self.build_acl_matches(**ftuple),
-            "FabricIngress.slice_tc_classifier.set_slice_id_tc",
-            [("slice_id", stringify(slice_id, 1)), ("tc", stringify(tc, 1))],
-            DEFAULT_PRIORITY,
-        )
-
-    def configure_slice_tc_meter(self, slice_id, tc, cir, cburst, pir, pburst):
-        self.write_indirect_meter(
-            m_name="FabricIngress.qos.slice_tc_meter",
-            m_index=self.slice_tc_index(slice_id, tc),
-            cir=cir,
-            cburst=cburst,
-            pir=pir,
-            pburst=pburst,
-        )
-
-    def add_queue_entry(self, slice_id, tc, qid=None, color=None):
-        matches = [
-            self.Exact("slice_id", stringify(slice_id, 1)),
-            self.Exact("tc", stringify(tc, 1)),
-        ]
-        if color is not None:
-            matches.append(
-                self.Ternary("color", stringify(color, 1), stringify(0x3, 1))
-            )
-        if qid is not None:
-            action = "FabricIngress.qos.set_queue"
-            action_params = [("qid", stringify(qid, 1))]
-        else:
-            action = "FabricIngress.qos.meter_drop"
-            action_params = []
-        self.send_request_add_entry_to_action(
-            "FabricIngress.qos.queues",
-            matches,
-            action,
-            action_params,
-            DEFAULT_PRIORITY,
-        )
-
-    def enable_policing(self, slice_id, tc, color=COLOR_RED):
-        self.add_queue_entry(slice_id, tc, None, color=color)
-
-
 class IPv4UnicastWithPolicingTest(SlicingTest, IPv4UnicastTest):
     """Tests QoS policer. This is mostly a dummmy test class to verify basic programming of
     QoS-related entities. Most of the QoS tests should use linerate traffic generation. """


### PR DESCRIPTION
Other modules, such as linerate tests, also need access to those helper functions. Currently, an import of slicing is not possible as it resides in a neighboring directory.
This change also makes all the functions return the (request, response) tuple.