### PR TITLE
Add script to format code locally

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Copyright 2021-present Open Networking Foundation
+# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0 AND Apache-2.0
+
+set -e
+
+python3 -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+python3 -m pip install black==19.10b0 isort==5.6.4
+black --config .github/linters/.python-black .
+isort --sp .github/linters/.isort.cfg .
+deactivate

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -21,12 +21,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8.5
-      - name: Install dependencies
-        run: python3 -m pip install black==19.10b0 isort==5.6.4
-      - name: Reformat code with Black
-        run: black --config .github/linters/.python-black .
-      - name: Refotmat code with isort
-        run: isort --sp .github/linters/.isort.cfg .
+      - name: Run code style and formatting tools
+        run: make format
       - name: Check if the code is modified
         run: git update-index --refresh || echo "create_pr=1" >> $GITHUB_ENV
       - name: Create pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Some additional points:
 
 1. Fork fabric-tna into your personal or organization account via the fork button on GitHub.
 
-2. Make your code changes.
+2. Make your code changes. Run `make format` to keep the code style consistent.
 
 3. Pass all tests locally (see [README.md](./README.md)). Create new tests for new code. Execute the following command in the root directory to run all currently enabled tests: `TODO: add command`
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ reuse-lint:
 env:
 	@cat $(RESOLVED_ENV) | grep -v "#"
 
+format:
+	.github/format.sh
+
 clean:
 	-rm -rf src/main/resources/p4c-out
 	-rm -rf p4src/build


### PR DESCRIPTION
This PR add the necessary tools and scripts so that running `make format` locally will format the code correctly.