### PR TITLE
Implement round robin line rate test for real time traffic

### DIFF
--- a/ptf/tests/common/qos_utils.py
+++ b/ptf/tests/common/qos_utils.py
@@ -14,21 +14,40 @@ from scapy.layers.all import IP, TCP, UDP, Ether
 SOURCE_MAC = "00:00:00:00:00:01"
 DEST_MAC = "00:00:00:00:00:02"
 
-# Semantic queue IDs
+# Semantic queue IDs. Must match the queue_mappings in chassis config!
 QUEUE_ID_BEST_EFFORT = 0
 QUEUE_ID_SYSTEM = 1
 QUEUE_ID_CONTROL = 2
+QUEUE_ID_REALTIME_1 = 3
+QUEUE_ID_REALTIME_2 = 4
+QUEUE_ID_REALTIME_3 = 5
 
 # Canonical L4 ports for different test traffic classes.
 L4_DPORT_BEST_EFFORT_TRAFFIC = 1000
-L4_DPORT_SYSTEM_TRAFFIC = 1001
-L4_DPORT_CONTROL_TRAFFIC = 1002
+L4_DPORT_ELASTIC_TRAFFIC = 2000
+L4_DPORT_SYSTEM_TRAFFIC = 3000
+L4_DPORT_REALTIME_TRAFFIC_1 = 4000
+L4_DPORT_REALTIME_TRAFFIC_2 = 4001
+L4_DPORT_REALTIME_TRAFFIC_3 = 4002
+L4_DPORT_CONTROL_TRAFFIC = 5000
 
 # Returns a packet that belongs to the control CoS group.
 def get_control_traffic_packet(l2_size=64):
     pkt = testutils.simple_udp_packet(
         eth_dst=DEST_MAC, udp_dport=L4_DPORT_CONTROL_TRAFFIC, pktlen=l2_size
     )
+    assert len(pkt) == l2_size, "Packet size {} does not match target size {}".format(
+        len(pkt), l2_size
+    )
+    return pkt
+
+
+# Returns a packet that belongs to the realtime CoS group.
+def get_realtime_traffic_packet(l2_size=64, dport=L4_DPORT_REALTIME_TRAFFIC_1):
+    assert (
+        L4_DPORT_REALTIME_TRAFFIC_1 <= dport <= L4_DPORT_REALTIME_TRAFFIC_3
+    ), "Invalid dport"
+    pkt = testutils.simple_udp_packet(eth_dst=DEST_MAC, udp_dport=dport, pktlen=l2_size)
     assert len(pkt) == l2_size, "Packet size {} does not match target size {}".format(
         len(pkt), l2_size
     )

--- a/ptf/tests/common/trex_test.py
+++ b/ptf/tests/common/trex_test.py
@@ -18,7 +18,9 @@ class TRexTest(P4RuntimeTest):
         self.trex_client.clear_stats()  # Clear status from all ports
         # Put all ports to promiscuous mode, otherwise they will drop all
         # incoming packets if the destination mac is not the port mac address.
-        self.trex_client.set_port_attr(self.trex_client.get_all_ports(), promiscuous=True)
+        self.trex_client.set_port_attr(
+            self.trex_client.get_all_ports(), promiscuous=True
+        )
 
     def tearDown(self):
         print("Tearing down STLClient...")

--- a/ptf/tests/common/trex_utils.py
+++ b/ptf/tests/common/trex_utils.py
@@ -126,52 +126,50 @@ LatencyStats = collections.namedtuple(
 )
 
 FlowStats = collections.namedtuple(
-    "FlowStats",
+    "FlowStats", ["pg_id", "total_tx", "total_rx", "tx_bytes", "rx_bytes",],
+)
+
+
+PortStats = collections.namedtuple(
+    "PortStats",
     [
-        "pg_id",
-        "total_tx",
-        "total_rx",
+        "tx_packets",
+        "rx_packets",
         "tx_bytes",
         "rx_bytes",
+        "tx_errors",
+        "rx_errors",
+        "tx_bps",
+        "tx_pps",
+        "tx_bps_L1",
+        "tx_util",
+        "rx_bps",
+        "rx_pps",
+        "rx_bps_L1",
+        "rx_util",
     ],
 )
 
 
-PortStats = collections.namedtuple("PortStats", [
-    "tx_packets",
-    "rx_packets",
-    "tx_bytes",
-    "rx_bytes",
-    "tx_errors",
-    "rx_errors",
-    "tx_bps",
-    "tx_pps",
-    "tx_bps_L1",
-    "tx_util",
-    "rx_bps",
-    "rx_pps",
-    "rx_bps_L1",
-    "rx_util",
-])
-
 def get_port_stats(port: int, stats) -> PortStats:
     port_stats = stats.get(port)
     return PortStats(
-        tx_packets = port_stats.get("opackets", 0),
-        rx_packets = port_stats.get("ipackets", 0),
-        tx_bytes = port_stats.get("obytes", 0),
-        rx_bytes = port_stats.get("ibytes", 0),
-        tx_errors = port_stats.get("oerrors", 0),
-        rx_errors = port_stats.get("ierrors", 0),
-        tx_bps = port_stats.get("tx_bps", 0),
-        tx_pps = port_stats.get("tx_pps", 0),
-        tx_bps_L1 = port_stats.get("tx_bps_L1", 0),
-        tx_util = port_stats.get("tx_util", 0),
-        rx_bps = port_stats.get("rx_bps", 0),
-        rx_pps = port_stats.get("rx_pps", 0),
-        rx_bps_L1 = port_stats.get("rx_bps_L1", 0),
-        rx_util = port_stats.get("rx_util", 0),
+        tx_packets=port_stats.get("opackets", 0),
+        rx_packets=port_stats.get("ipackets", 0),
+        tx_bytes=port_stats.get("obytes", 0),
+        rx_bytes=port_stats.get("ibytes", 0),
+        tx_errors=port_stats.get("oerrors", 0),
+        rx_errors=port_stats.get("ierrors", 0),
+        tx_bps=port_stats.get("tx_bps", 0),
+        tx_pps=port_stats.get("tx_pps", 0),
+        tx_bps_L1=port_stats.get("tx_bps_L1", 0),
+        tx_util=port_stats.get("tx_util", 0),
+        rx_bps=port_stats.get("rx_bps", 0),
+        rx_pps=port_stats.get("rx_pps", 0),
+        rx_bps_L1=port_stats.get("rx_bps_L1", 0),
+        rx_util=port_stats.get("rx_util", 0),
     )
+
 
 def get_latency_stats(pg_id: int, stats) -> LatencyStats:
     lat_stats = stats["latency"].get(pg_id)
@@ -227,7 +225,7 @@ def get_readable_latency_stats(stats: LatencyStats) -> str:
         val = stats.histogram[sample]
         histogram = (
             histogram
-            + "\n        Packets with latency between {0:>4} us and {1:>4} us: {2:>10}".format(
+            + "\n        Packets with latency between {0:>5} us and {1:>5} us: {2:>10}".format(
                 range_start, range_end, val
             )
         )


### PR DESCRIPTION
This PR adds a line rate test that check if traffic in the round robin realtime slice is handled correctly.


Exemplary run:

```
qos_tests.RealtimeTrafficIsRrScheduled ...
    Latency info for pg_id 1
    Dropped packets: 34334
    Out-of-order packets: 0
    Sequence too high packets: 4938
    Sequence too low packets: 0
    Maximum latency: 59477 us
    Minimum latency: 4 us
    Maximum latency in last sampling period: 54116 us
    Average latency: 53822.0 us
    50th percentile latency: 60000.0 us
    75th percentile latency: 60000.0 us
    90th percentile latency: 60000.0 us
    99th percentile latency: 60000.0 us
    Jitter: 42 us
    Latency distribution histogram:
        Packets with latency between     0 us and    10 us:       2309
        Packets with latency between    10 us and    20 us:         65
        Packets with latency between    20 us and    30 us:         15
        Packets with latency between    30 us and    40 us:         11
        Packets with latency between    40 us and    50 us:          6
        Packets with latency between    50 us and    60 us:         10
        Packets with latency between    60 us and    70 us:          5
        Packets with latency between    70 us and    80 us:          8
        Packets with latency between    80 us and    90 us:          6
        Packets with latency between    90 us and   100 us:          5
        Packets with latency between   100 us and   200 us:         46
        Packets with latency between   200 us and   300 us:         48
        Packets with latency between   300 us and   400 us:         42
        Packets with latency between   400 us and   500 us:         40
        Packets with latency between   500 us and   600 us:         41
        Packets with latency between   600 us and   700 us:         40
        Packets with latency between   700 us and   800 us:         42
        Packets with latency between   800 us and   900 us:         43
        Packets with latency between   900 us and  1000 us:         41
        Packets with latency between  1000 us and  2000 us:        407
        Packets with latency between  2000 us and  3000 us:        411
        Packets with latency between  3000 us and  4000 us:        408
        Packets with latency between  4000 us and  5000 us:        407
        Packets with latency between  5000 us and  6000 us:        419
        Packets with latency between  6000 us and  7000 us:        410
        Packets with latency between  7000 us and  8000 us:        410
        Packets with latency between  8000 us and  9000 us:        407
        Packets with latency between  9000 us and 10000 us:        408
        Packets with latency between 10000 us and 20000 us:       4108
        Packets with latency between 20000 us and 30000 us:       4106
        Packets with latency between 30000 us and 40000 us:       4102
        Packets with latency between 40000 us and 50000 us:       4103
        Packets with latency between 50000 us and 60000 us:     347775


    Latency info for pg_id 2
    Dropped packets: 22156
    Out-of-order packets: 0
    Sequence too high packets: 6301
    Sequence too low packets: 0
    Maximum latency: 81322 us
    Minimum latency: 4 us
    Maximum latency in last sampling period: 81322 us
    Average latency: 80824.0 us
    50th percentile latency: 90000.0 us
    75th percentile latency: 90000.0 us
    90th percentile latency: 90000.0 us
    99th percentile latency: 90000.0 us
    Jitter: 70 us
    Latency distribution histogram:
        Packets with latency between     0 us and    10 us:      50732
        Packets with latency between    10 us and    20 us:         60
        Packets with latency between    20 us and    30 us:          8
        Packets with latency between    30 us and    40 us:          7
        Packets with latency between    40 us and    50 us:          4
        Packets with latency between    50 us and    60 us:          8
        Packets with latency between    60 us and    70 us:          5
        Packets with latency between    70 us and    80 us:          4
        Packets with latency between    80 us and    90 us:          4
        Packets with latency between    90 us and   100 us:          5
        Packets with latency between   100 us and   200 us:         51
        Packets with latency between   200 us and   300 us:         35
        Packets with latency between   300 us and   400 us:         16
        Packets with latency between   400 us and   500 us:         28
        Packets with latency between   500 us and   600 us:         32
        Packets with latency between   600 us and   700 us:         31
        Packets with latency between   700 us and   800 us:         20
        Packets with latency between   800 us and   900 us:         23
        Packets with latency between   900 us and  1000 us:         30
        Packets with latency between  1000 us and  2000 us:        281
        Packets with latency between  2000 us and  3000 us:        276
        Packets with latency between  3000 us and  4000 us:        276
        Packets with latency between  4000 us and  5000 us:        273
        Packets with latency between  5000 us and  6000 us:        272
        Packets with latency between  6000 us and  7000 us:        275
        Packets with latency between  7000 us and  8000 us:        273
        Packets with latency between  8000 us and  9000 us:        273
        Packets with latency between  9000 us and 10000 us:        270
        Packets with latency between 10000 us and 20000 us:       2737
        Packets with latency between 20000 us and 30000 us:       2742
        Packets with latency between 30000 us and 40000 us:       2729
        Packets with latency between 40000 us and 50000 us:       2742
        Packets with latency between 50000 us and 60000 us:       2738
        Packets with latency between 60000 us and 70000 us:       2721
        Packets with latency between 70000 us and 80000 us:       2750
        Packets with latency between 80000 us and 90000 us:     223565


    Latency info for pg_id 3
    Dropped packets: 0
    Out-of-order packets: 0
    Sequence too high packets: 0
    Sequence too low packets: 0
    Maximum latency: 497 us
    Minimum latency: 4 us
    Maximum latency in last sampling period: 20 us
    Average latency: 4.0 us
    50th percentile latency: 10.0 us
    75th percentile latency: 10.0 us
    90th percentile latency: 10.0 us
    99th percentile latency: 10.0 us
    Jitter: 0 us
    Latency distribution histogram:
        Packets with latency between     0 us and    10 us:   14050195
        Packets with latency between    10 us and    20 us:       1467
        Packets with latency between    20 us and    30 us:        194
        Packets with latency between    30 us and    40 us:          4
        Packets with latency between    40 us and    50 us:          1
        Packets with latency between    50 us and    60 us:          1
        Packets with latency between    60 us and    70 us:          1
        Packets with latency between   100 us and   200 us:          2
        Packets with latency between   200 us and   300 us:          2
        Packets with latency between   300 us and   400 us:          2
        Packets with latency between   400 us and   500 us:          3

Statistics for port 0:
    Output packets: 0
    Input packets: 0
    Output bytes: 0 (0.0 Bytes)
    Input bytes: 0 (0.0 Bytes)
    Output errors: 0
    Input errors: 0
    TX bps: 352.8370056152344 (352.8 bps)
    TX pps: 0.03141352906823158 (0.0 pps)
    L1 TX bps: 357.86317026615137 (357.9 bps)
    TX util: 8.946579256653784e-07
    RX bps: 0.0 (0.0 bps)
    RX pps: 0.0 (0.0 pps)
    L1 RX bps: 0 (0.0 bps)
    RX util: 0.0
Statistics for port 1:
    Output packets: 0
    Input packets: 823138
    Output bytes: 0 (0.0 Bytes)
    Input bytes: 108654216 (108.7 MBytes)
    Output errors: 0
    Input errors: 0
    TX bps: 0.0 (0.0 bps)
    TX pps: 0.0 (0.0 pps)
    L1 TX bps: 0 (0.0 bps)
    TX util: 0.0
    RX bps: 86665048.0 (86.7 Mbps)
    RX pps: 82069.171875 (82.1 Kpps)
    L1 RX bps: 99796115.5 (99.8 Mbps)
    RX util: 0.24949028874999998
Statistics for port 2:
    Output packets: 879628
    Input packets: 0
    Output bytes: 116110896 (116.1 MBytes)
    Input bytes: 0 (0.0 Bytes)
    Output errors: 0
    Input errors: 0
    TX bps: 84799464.0 (84.8 Mbps)
    TX pps: 80302.5234375 (80.3 Kpps)
    L1 TX bps: 97647867.75 (97.6 Mbps)
    TX util: 0.244119669375
    RX bps: 0.0 (0.0 bps)
    RX pps: 0.0 (0.0 pps)
    L1 RX bps: 0 (0.0 bps)
    RX util: 0.0
Tearing down STLClient...
ok
```