### PR TITLE
[SDFAB-338] Revisit DistributedFabricUpfStore in fabric-tna.p4

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/cli/ReadInternalUpfStoreCommand.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/cli/ReadInternalUpfStoreCommand.java
@@ -33,10 +33,10 @@ public class ReadInternalUpfStoreCommand extends AbstractShellCommand {
             return;
         }
 
-        Map<UpfRuleIdentifier, Integer> farIdMap = upfStore.getFarIdMap();
-        print("farIdMap size: " + farIdMap.size());
+        Map<Integer, UpfRuleIdentifier> reverseFarIdMap = upfStore.getReverseFarIdMap();
+        print("reverseFarIdMap size: " + reverseFarIdMap.size());
         if (verbose) {
-            farIdMap.entrySet().forEach(entry -> print(entry.toString()));
+            reverseFarIdMap.entrySet().forEach(entry -> print(entry.toString()));
         }
     }
 }

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/DistributedFabricUpfStore.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/DistributedFabricUpfStore.java
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
 package org.stratumproject.fabric.tna.behaviour.upf;
 
-import com.google.common.collect.Maps;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import org.onlab.util.ImmutableByteSequence;
 import org.onlab.util.KryoNamespace;
 import org.onosproject.store.serializers.KryoNamespaces;
-import org.onosproject.store.service.ConsistentMap;
-import org.onosproject.store.service.MapEvent;
-import org.onosproject.store.service.MapEventListener;
-import org.onosproject.store.service.Serializer;
+import org.onosproject.store.service.EventuallyConsistentMap;
 import org.onosproject.store.service.StorageService;
+import org.onosproject.store.service.WallClockTimestamp;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Distributed implementation of FabricUpfStore.
@@ -39,61 +39,54 @@ public final class DistributedFabricUpfStore implements FabricUpfStore {
             .register(KryoNamespaces.API)
             .register(UpfRuleIdentifier.class);
 
-    // Distributed local FAR ID to global FAR ID mapping
-    protected ConsistentMap<UpfRuleIdentifier, Integer> farIdMap;
-    private MapEventListener<UpfRuleIdentifier, Integer> farIdMapListener;
-    // Local, reversed copy of farIdMapper for better reverse lookup performance
-    protected Map<Integer, UpfRuleIdentifier> reverseFarIdMap;
-    private int nextGlobalFarId = 1;
+    // EC map to remember the mapping far_id -> rule_id this is mostly used during reads,
+    // it can be definitely removed by simplifying the logical pipeline
+    protected EventuallyConsistentMap<Integer, UpfRuleIdentifier> reverseFarIdMap;
 
     @Activate
     protected void activate() {
-        // Allow unit test to inject farIdMap here.
+        // Allow unit test to inject reverseFarIdMap here.
         if (storageService != null) {
-            this.farIdMap = storageService.<UpfRuleIdentifier, Integer>consistentMapBuilder()
+            this.reverseFarIdMap = storageService.<Integer, UpfRuleIdentifier>eventuallyConsistentMapBuilder()
                     .withName(FAR_ID_MAP_NAME)
-                    .withRelaxedReadConsistency()
-                    .withSerializer(Serializer.using(SERIALIZER.build()))
+                    .withSerializer(SERIALIZER)
+                    .withTimestampProvider((k, v) -> new WallClockTimestamp())
                     .build();
-
         }
-        farIdMapListener = new FarIdMapListener();
-        farIdMap.addListener(farIdMapListener);
-
-        reverseFarIdMap = Maps.newHashMap();
-        farIdMap.entrySet().forEach(entry -> reverseFarIdMap.put(entry.getValue().value(), entry.getKey()));
 
         log.info("Started");
     }
 
     @Deactivate
     protected void deactivate() {
-        farIdMap.removeListener(farIdMapListener);
-        farIdMap.destroy();
-        reverseFarIdMap.clear();
+        reverseFarIdMap.destroy();
 
         log.info("Stopped");
     }
 
     @Override
     public void reset() {
-        farIdMap.clear();
         reverseFarIdMap.clear();
-        nextGlobalFarId = 0;
     }
 
     @Override
-    public Map<UpfRuleIdentifier, Integer> getFarIdMap() {
-        return Map.copyOf(farIdMap.asJavaMap());
+    public Map<Integer, UpfRuleIdentifier> getReverseFarIdMap() {
+        return reverseFarIdMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override
     public int globalFarIdOf(UpfRuleIdentifier farIdPair) {
-        int globalFarId = farIdMap.compute(farIdPair,
-                (k, existingId) -> {
-                    return Objects.requireNonNullElseGet(existingId, () -> nextGlobalFarId++);
-                }).value();
+        int globalFarId = getGlobalFarIdOf(farIdPair);
+        reverseFarIdMap.put(globalFarId, farIdPair);
         log.info("{} translated to GlobalFarId={}", farIdPair, globalFarId);
+        return globalFarId;
+    }
+
+    @Override
+    public int removeGlobalFarId(UpfRuleIdentifier farIdPair) {
+        int globalFarId = getGlobalFarIdOf(farIdPair);
+        reverseFarIdMap.remove(globalFarId);
         return globalFarId;
     }
 
@@ -105,29 +98,24 @@ public final class DistributedFabricUpfStore implements FabricUpfStore {
     }
 
     @Override
+    public int removeGlobalFarId(ImmutableByteSequence pfcpSessionId, int sessionLocalFarId) {
+        UpfRuleIdentifier farId = new UpfRuleIdentifier(pfcpSessionId, sessionLocalFarId);
+        return removeGlobalFarId(farId);
+    }
+
+    @Override
     public UpfRuleIdentifier localFarIdOf(int globalFarId) {
         return reverseFarIdMap.get(globalFarId);
     }
 
-    // NOTE: FarIdMapListener is run on the same thread intentionally in order to ensure that
-    //       reverseFarIdMap update always finishes right after farIdMap is updated
-    private class FarIdMapListener implements MapEventListener<UpfRuleIdentifier, Integer> {
-        @Override
-        public void event(MapEvent<UpfRuleIdentifier, Integer> event) {
-            switch (event.type()) {
-                case INSERT:
-                    reverseFarIdMap.put(event.newValue().value(), event.key());
-                    break;
-                case UPDATE:
-                    reverseFarIdMap.remove(event.oldValue().value());
-                    reverseFarIdMap.put(event.newValue().value(), event.key());
-                    break;
-                case REMOVE:
-                    reverseFarIdMap.remove(event.oldValue().value());
-                    break;
-                default:
-                    break;
-            }
-        }
+    // Compute global far id by hashing the pfcp session id and the session local far
+    private int getGlobalFarIdOf(UpfRuleIdentifier farIdPair) {
+        HashFunction hashFunction = Hashing.murmur3_32();
+        HashCode hashCode = hashFunction.newHasher()
+                .putInt(farIdPair.getSessionLocalId())
+                .putBytes(farIdPair.getPfcpSessionId().asArray())
+                .hash();
+        return hashCode.asInt();
     }
+
 }

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
@@ -567,7 +567,7 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
         log.info("Removing {}", far.toString());
 
         PiCriterion match = PiCriterion.builder()
-                .matchExact(HDR_FAR_ID, fabricUpfStore.globalFarIdOf(far.sessionId(), far.farId()))
+                .matchExact(HDR_FAR_ID, fabricUpfStore.removeGlobalFarId(far.sessionId(), far.farId()))
                 .build();
 
         removeEntry(match, FABRIC_INGRESS_SPGW_FARS, false);

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfStore.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfStore.java
@@ -16,11 +16,11 @@ public interface FabricUpfStore {
     void reset();
 
     /**
-     * Returns the farIdMap.
+     * Returns the reverseFarIdMap.
      *
      * @return the farIdMap.
      */
-    Map<UpfRuleIdentifier, Integer> getFarIdMap();
+    Map<Integer, UpfRuleIdentifier> getReverseFarIdMap();
 
     /**
      * Get a globally unique integer identifier for the FAR identified by the given (Session ID, Far
@@ -32,6 +32,14 @@ public interface FabricUpfStore {
     int globalFarIdOf(UpfRuleIdentifier farIdPair);
 
     /**
+     * Remove the global far id from the system.
+     *
+     * @param farIdPair a RuleIdentifier instance uniquely identifying the FAR
+     * @return A globally unique integer identifier
+     */
+    int removeGlobalFarId(UpfRuleIdentifier farIdPair);
+
+    /**
      * Get a globally unique integer identifier for the FAR identified by the given (Session ID, Far
      * ID) pair.
      *
@@ -40,6 +48,15 @@ public interface FabricUpfStore {
      * @return A globally unique integer identifier
      */
     int globalFarIdOf(ImmutableByteSequence pfcpSessionId, int sessionLocalFarId);
+
+    /**
+     * Remove the global far id from the system.
+     *
+     * @param pfcpSessionId     The ID of the PFCP session that produced the FAR ID.
+     * @param sessionLocalFarId The FAR ID.
+     * @return A globally unique integer identifier
+     */
+    int removeGlobalFarId(ImmutableByteSequence pfcpSessionId, int sessionLocalFarId);
 
     /**
      * Get the corresponding PFCP session ID and session-local FAR ID from a globally unique FAR ID,

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslator.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslator.java
@@ -131,6 +131,9 @@ public class FabricUpfTranslator {
         // Grab keys and parameters that are present for all PDRs
         int globalFarId = FabricUpfTranslatorUtil.getParamInt(action, FAR_ID);
         UpfRuleIdentifier farId = fabricUpfStore.localFarIdOf(globalFarId);
+        if (farId == null) {
+            throw new UpfProgrammableException(String.format("Unable to find local far id of %s", globalFarId));
+        }
 
         pdrBuilder.withCounterId(FabricUpfTranslatorUtil.getParamInt(action, CTR_ID))
                 .withLocalFarId(farId.getSessionLocalId())
@@ -169,6 +172,9 @@ public class FabricUpfTranslator {
 
         int globalFarId = FabricUpfTranslatorUtil.getFieldInt(match, HDR_FAR_ID);
         UpfRuleIdentifier farId = fabricUpfStore.localFarIdOf(globalFarId);
+        if (farId == null) {
+            throw new UpfProgrammableException(String.format("Unable to find local far id of %s", globalFarId));
+        }
 
         boolean dropFlag = FabricUpfTranslatorUtil.getParamInt(action, DROP) > 0;
         boolean notifyFlag = FabricUpfTranslatorUtil.getParamInt(action, NOTIFY_CP) > 0;

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestDistributedFabricUpfStore.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestDistributedFabricUpfStore.java
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
 package org.stratumproject.fabric.tna.behaviour.upf;
 
-import org.onosproject.store.service.Serializer;
-import org.onosproject.store.service.TestConsistentMap;
+import org.onosproject.store.service.TestEventuallyConsistentMap;
+import org.onosproject.store.service.WallClockTimestamp;
 
 import static org.stratumproject.fabric.tna.behaviour.upf.DistributedFabricUpfStore.FAR_ID_MAP_NAME;
 import static org.stratumproject.fabric.tna.behaviour.upf.DistributedFabricUpfStore.SERIALIZER;
@@ -15,22 +15,20 @@ public final class TestDistributedFabricUpfStore {
 
     public static DistributedFabricUpfStore build() {
         var store = new DistributedFabricUpfStore();
-        TestConsistentMap.Builder<UpfRuleIdentifier, Integer> farIdMapBuilder =
-                TestConsistentMap.builder();
-        farIdMapBuilder.withName(FAR_ID_MAP_NAME)
-                .withRelaxedReadConsistency()
-                .withSerializer(Serializer.using(SERIALIZER.build()));
-        store.farIdMap = farIdMapBuilder.build();
+        TestEventuallyConsistentMap.Builder<Integer, UpfRuleIdentifier> reverseFarIdMapBuilder =
+                TestEventuallyConsistentMap.builder();
+        reverseFarIdMapBuilder.withName(FAR_ID_MAP_NAME)
+                .withTimestampProvider((k, v) -> new WallClockTimestamp())
+                .withSerializer(SERIALIZER.build());
+        store.reverseFarIdMap = reverseFarIdMapBuilder.build();
 
         store.activate();
 
         // Init with some translation state.
-        store.farIdMap.put(
-                new UpfRuleIdentifier(TestUpfConstants.SESSION_ID, TestUpfConstants.UPLINK_FAR_ID),
-                TestUpfConstants.UPLINK_PHYSICAL_FAR_ID);
-        store.farIdMap.put(
-                new UpfRuleIdentifier(TestUpfConstants.SESSION_ID, TestUpfConstants.DOWNLINK_FAR_ID),
-                TestUpfConstants.DOWNLINK_PHYSICAL_FAR_ID);
+        store.reverseFarIdMap.put(TestUpfConstants.UPLINK_PHYSICAL_FAR_ID,
+                new UpfRuleIdentifier(TestUpfConstants.SESSION_ID, TestUpfConstants.UPLINK_FAR_ID));
+        store.reverseFarIdMap.put(TestUpfConstants.DOWNLINK_PHYSICAL_FAR_ID,
+                new UpfRuleIdentifier(TestUpfConstants.SESSION_ID, TestUpfConstants.DOWNLINK_FAR_ID));
 
         return store;
     }

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
 package org.stratumproject.fabric.tna.behaviour.upf;
 
+import com.google.common.hash.Hashing;
 import org.onlab.packet.Ip4Address;
 import org.onlab.packet.Ip4Prefix;
 import org.onlab.util.ImmutableByteSequence;
@@ -58,9 +59,19 @@ public final class TestUpfConstants {
     public static final int DOWNLINK_COUNTER_CELL_ID = 2;
     public static final int PDR_ID = 0;  // TODO: PDR ID currently not stored on writes, so all reads are 0
     public static final int UPLINK_FAR_ID = 1;
-    public static final int UPLINK_PHYSICAL_FAR_ID = 4;
+    public static final int UPLINK_PHYSICAL_FAR_ID = Hashing.murmur3_32()
+            .newHasher()
+            .putInt(UPLINK_FAR_ID)
+            .putBytes(SESSION_ID.asArray())
+            .hash()
+            .asInt();
     public static final int DOWNLINK_FAR_ID = 2;
-    public static final int DOWNLINK_PHYSICAL_FAR_ID = 5;
+    public static final int DOWNLINK_PHYSICAL_FAR_ID = Hashing.murmur3_32()
+                        .newHasher()
+            .putInt(DOWNLINK_FAR_ID)
+            .putBytes(SESSION_ID.asArray())
+            .hash()
+            .asInt();
 
     public static final int UPLINK_PRIORITY = 9;
     public static final int DOWNLINK_PRIORITY = 1;


### PR DESCRIPTION
Remove the global far id consistent map and uses consistent hashing for the allocation of the farId. Stores the reverse lookup (far -> ruleId) into an EC consistent map and purges its entries on the far removal