### PR TITLE
Add 99.9th, 99.99th and 99.999th latency percentiles

### DIFF
--- a/ptf/tests/common/trex_utils.py
+++ b/ptf/tests/common/trex_utils.py
@@ -122,6 +122,9 @@ LatencyStats = collections.namedtuple(
         "percentile_75",
         "percentile_90",
         "percentile_99",
+        "percentile_99_9",
+        "percentile_99_99",
+        "percentile_99_999",
     ],
 )
 
@@ -187,7 +190,7 @@ def get_latency_stats(pg_id: int, stats) -> LatencyStats:
         val = lat["histogram"][sample]
         # Assume whole the bucket experienced the range_end latency.
         all_latencies += [range_end] * val
-    q = [50, 75, 90, 99]
+    q = [50, 75, 90, 99, 99.9, 99.99, 99.999]
     percentiles = np.percentile(all_latencies, q)
 
     ret = LatencyStats(
@@ -207,6 +210,9 @@ def get_latency_stats(pg_id: int, stats) -> LatencyStats:
         percentile_75=percentiles[1],
         percentile_90=percentiles[2],
         percentile_99=percentiles[3],
+        percentile_99_9=percentiles[4],
+        percentile_99_99=percentiles[5],
+        percentile_99_999=percentiles[6],
     )
     return ret
 
@@ -244,6 +250,9 @@ def get_readable_latency_stats(stats: LatencyStats) -> str:
     75th percentile latency: {stats.percentile_75} us
     90th percentile latency: {stats.percentile_90} us
     99th percentile latency: {stats.percentile_99} us
+    99.9th percentile latency: {stats.percentile_99_9} us
+    99.99th percentile latency: {stats.percentile_99_99} us
+    99.999th percentile latency: {stats.percentile_99_999} us
     Jitter: {stats.jitter} us
     Latency distribution histogram: {histogram}
     """


### PR DESCRIPTION
Most users will send more than a single packet. The aggregate probability of experiencing a super slow latency (i.e. 99th 'tile) increases dramatically with the number of packets sent: [1 - p^n](https://www.wolframalpha.com/input/?i=plot+1+-+%28Power%5B.99%2CN%5D%29%2C+1%3CN%3C200)

![image](https://user-images.githubusercontent.com/7455710/127910045-5f4f1211-dc45-48fc-9ce5-cb34a102bce7.png)

Therefore, we add more nines to the reported stats, up to the 99.999th 'ile.

Example:

```
    Latency info for pg_id 3
    Dropped packets: 0
    Out-of-order packets: 0
    Sequence too high packets: 0
    Sequence too low packets: 0
    Maximum latency: 309 us
    Minimum latency: 4 us
    Maximum latency in last sampling period: 20 us
    Average latency: 4.0 us
    50th percentile latency: 10.0 us
    75th percentile latency: 10.0 us
    90th percentile latency: 10.0 us
    99th percentile latency: 10.0 us
    99.9th percentile latency: 10.0 us
    99.99th percentile latency: 20.0 us
    99.999th percentile latency: 30.0 us
    Jitter: 0 us
    Latency distribution histogram:
        Packets with latency between     0 us and    10 us:   14046923
        Packets with latency between    10 us and    20 us:       1318
        Packets with latency between    20 us and    30 us:        147
        Packets with latency between    30 us and    40 us:          1
        Packets with latency between    40 us and    50 us:          6
        Packets with latency between    60 us and    70 us:          1
        Packets with latency between   100 us and   200 us:          2
        Packets with latency between   200 us and   300 us:          2
        Packets with latency between   300 us and   400 us:          1
```