### PR TITLE
SDFAB-379] Optimize the resource usage of the L3 unicast groups

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/NextObjectiveTranslator.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/NextObjectiveTranslator.java
@@ -40,6 +40,7 @@ import org.stratumproject.fabric.tna.behaviour.P4InfoConstants;
 import org.stratumproject.fabric.tna.behaviour.FabricUtils;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -262,8 +263,18 @@ class NextObjectiveTranslator
             return;
         }
 
-        // Updated result builder with hashed group.
-        final int groupId = selectGroup(obj, resultBuilder);
+        // Updated result builder with hashed group or indirect group
+        // use indirect group allow us to optimize the resource in those
+        // devices that preallocate memory based on the maxGroupSize
+        final int groupId;
+        if (obj.type() == NextObjective.Type.HASHED) {
+            groupId = selectGroup(obj, resultBuilder);
+        } else if (obj.type() == NextObjective.Type.SIMPLE) {
+            groupId = indirectGroup(obj, resultBuilder);
+        } else {
+            throw new FabricPipelinerException("Cannot translate BROADCAST next objective" +
+                    "into hashedNext actions");
+        }
 
         if (isGroupModifyOp(obj) || obj.op() == Objective.Operation.VERIFY) {
             // No changes to flow rules.
@@ -496,6 +507,44 @@ class NextObjectiveTranslator
                         groupKey,
                         groupId,
                         obj.appId()));
+
+        return groupId;
+    }
+
+    private int indirectGroup(NextObjective obj,
+                              ObjectiveTranslation.Builder resultBuilder)
+            throws FabricPipelinerException {
+
+        if (isGroupModifyOp(obj)) {
+            throw new FabricPipelinerException("Simple next objective does not support" +
+                    "*_TO_EXISTING operations");
+        }
+
+        final PiTableId hashedTableId = P4InfoConstants.FABRIC_INGRESS_NEXT_HASHED;
+        final List<DefaultNextTreatment> defaultNextTreatments =
+                defaultNextTreatments(obj.nextTreatments(), true);
+
+        if (defaultNextTreatments.size() != 1) {
+            throw new FabricPipelinerException("Simple next objective must have a single" +
+                    " treatment");
+        }
+
+        final TrafficTreatment piTreatment;
+        final DefaultNextTreatment defaultNextTreatment = defaultNextTreatments.get(0);
+        piTreatment = mapTreatmentToPiIfNeeded(defaultNextTreatment.treatment(), hashedTableId);
+        handleEgress(obj, defaultNextTreatment.treatment(), resultBuilder, false);
+        final GroupBucket groupBucket = DefaultGroupBucket.createIndirectGroupBucket(piTreatment);
+
+        final int groupId = obj.id();
+        final PiGroupKey groupKey = (PiGroupKey) getGroupKey(obj);
+
+        resultBuilder.addGroup(new DefaultGroupDescription(
+                deviceId,
+                GroupDescription.Type.INDIRECT,
+                new GroupBuckets(Collections.singletonList(groupBucket)),
+                groupKey,
+                groupId,
+                obj.appId()));
 
         return groupId;
     }


### PR DESCRIPTION
This is achieved by translating SIMPLE next objective into INDIRECT groups. By default SELECT groups are always used which has as side effect the creation of action profile groups with the maxGroupSize derived from the action profile model.

Instead, PiGroupTranslator sets always to 1 the maxGroupSize of action profile groups derived from a INDIRECT groups which allows us to achieve a better scale for target devices pre-allocating memory according to the maxGroupSize.