### PR TITLE
Generate match field bitwidth in P4InfoConstants

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -25,72 +25,108 @@ public final class P4InfoConstants {
     // Header field IDs
     public static final PiMatchFieldId HDR_BMD_TYPE =
             PiMatchFieldId.of("bmd_type");
+    public static final int HDR_BMD_TYPE_BITWIDTH = 8;
     public static final PiMatchFieldId HDR_COLOR = PiMatchFieldId.of("color");
+    public static final int HDR_COLOR_BITWIDTH = 2;
     public static final PiMatchFieldId HDR_EG_PORT =
             PiMatchFieldId.of("eg_port");
+    public static final int HDR_EG_PORT_BITWIDTH = 9;
     public static final PiMatchFieldId HDR_EGRESS_QID =
             PiMatchFieldId.of("egress_qid");
+    public static final int HDR_EGRESS_QID_BITWIDTH = 5;
     public static final PiMatchFieldId HDR_ETH_DST =
             PiMatchFieldId.of("eth_dst");
+    public static final int HDR_ETH_DST_BITWIDTH = 48;
     public static final PiMatchFieldId HDR_ETH_SRC =
             PiMatchFieldId.of("eth_src");
+    public static final int HDR_ETH_SRC_BITWIDTH = 48;
     public static final PiMatchFieldId HDR_ETH_TYPE =
             PiMatchFieldId.of("eth_type");
+    public static final int HDR_ETH_TYPE_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_FAR_ID = PiMatchFieldId.of("far_id");
+    public static final int HDR_FAR_ID_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_GTPU_IS_VALID =
             PiMatchFieldId.of("gtpu_is_valid");
+    public static final int HDR_GTPU_IS_VALID_BITWIDTH = 1;
     public static final PiMatchFieldId HDR_HOP_LATENCY_LOWER =
             PiMatchFieldId.of("hop_latency_lower");
+    public static final int HDR_HOP_LATENCY_LOWER_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_HOP_LATENCY_UPPER =
             PiMatchFieldId.of("hop_latency_upper");
+    public static final int HDR_HOP_LATENCY_UPPER_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_ICMP_CODE =
             PiMatchFieldId.of("icmp_code");
+    public static final int HDR_ICMP_CODE_BITWIDTH = 8;
     public static final PiMatchFieldId HDR_ICMP_TYPE =
             PiMatchFieldId.of("icmp_type");
+    public static final int HDR_ICMP_TYPE_BITWIDTH = 8;
     public static final PiMatchFieldId HDR_IG_PORT =
             PiMatchFieldId.of("ig_port");
+    public static final int HDR_IG_PORT_BITWIDTH = 9;
     public static final PiMatchFieldId HDR_IG_PORT_TYPE =
             PiMatchFieldId.of("ig_port_type");
+    public static final int HDR_IG_PORT_TYPE_BITWIDTH = 2;
     public static final PiMatchFieldId HDR_INT_REPORT_TYPE =
             PiMatchFieldId.of("int_report_type");
+    public static final int HDR_INT_REPORT_TYPE_BITWIDTH = 3;
     public static final PiMatchFieldId HDR_IP_ETH_TYPE =
             PiMatchFieldId.of("ip_eth_type");
+    public static final int HDR_IP_ETH_TYPE_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_IP_PROTO =
             PiMatchFieldId.of("ip_proto");
+    public static final int HDR_IP_PROTO_BITWIDTH = 8;
     public static final PiMatchFieldId HDR_IPV4_DST =
             PiMatchFieldId.of("ipv4_dst");
+    public static final int HDR_IPV4_DST_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_IPV4_DST_ADDR =
             PiMatchFieldId.of("ipv4_dst_addr");
+    public static final int HDR_IPV4_DST_ADDR_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_IPV4_SRC =
             PiMatchFieldId.of("ipv4_src");
+    public static final int HDR_IPV4_SRC_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_IPV4_VALID =
             PiMatchFieldId.of("ipv4_valid");
+    public static final int HDR_IPV4_VALID_BITWIDTH = 1;
     public static final PiMatchFieldId HDR_IPV6_DST =
             PiMatchFieldId.of("ipv6_dst");
+    public static final int HDR_IPV6_DST_BITWIDTH = 128;
     public static final PiMatchFieldId HDR_L4_DPORT =
             PiMatchFieldId.of("l4_dport");
+    public static final int HDR_L4_DPORT_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_L4_SPORT =
             PiMatchFieldId.of("l4_sport");
+    public static final int HDR_L4_SPORT_BITWIDTH = 16;
     public static final PiMatchFieldId HDR_MIRROR_TYPE =
             PiMatchFieldId.of("mirror_type");
+    public static final int HDR_MIRROR_TYPE_BITWIDTH = 3;
     public static final PiMatchFieldId HDR_MPLS_LABEL =
             PiMatchFieldId.of("mpls_label");
+    public static final int HDR_MPLS_LABEL_BITWIDTH = 20;
     public static final PiMatchFieldId HDR_NEXT_ID =
             PiMatchFieldId.of("next_id");
+    public static final int HDR_NEXT_ID_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_SLICE_ID =
             PiMatchFieldId.of("slice_id");
+    public static final int HDR_SLICE_ID_BITWIDTH = 4;
     public static final PiMatchFieldId HDR_STATS_FLOW_ID =
             PiMatchFieldId.of("stats_flow_id");
+    public static final int HDR_STATS_FLOW_ID_BITWIDTH = 10;
     public static final PiMatchFieldId HDR_TC = PiMatchFieldId.of("tc");
+    public static final int HDR_TC_BITWIDTH = 2;
     public static final PiMatchFieldId HDR_TEID = PiMatchFieldId.of("teid");
+    public static final int HDR_TEID_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_TUNNEL_IPV4_DST =
             PiMatchFieldId.of("tunnel_ipv4_dst");
+    public static final int HDR_TUNNEL_IPV4_DST_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_UE_ADDR =
             PiMatchFieldId.of("ue_addr");
+    public static final int HDR_UE_ADDR_BITWIDTH = 32;
     public static final PiMatchFieldId HDR_VLAN_ID =
             PiMatchFieldId.of("vlan_id");
+    public static final int HDR_VLAN_ID_BITWIDTH = 12;
     public static final PiMatchFieldId HDR_VLAN_IS_VALID =
             PiMatchFieldId.of("vlan_is_valid");
+    public static final int HDR_VLAN_IS_VALID_BITWIDTH = 1;
     // Table IDs
     public static final PiTableId FABRIC_EGRESS_DSCP_REWRITER_REWRITER =
             PiTableId.of("FabricEgress.dscp_rewriter.rewriter");

--- a/util/gen-p4-constants.py
+++ b/util/gen-p4-constants.py
@@ -48,6 +48,9 @@ JAVA_DOC_FMT = """/**
 PI_HF_FIELD_ID = "PiMatchFieldId"
 PI_HF_FIELD_ID_CST = 'PiMatchFieldId.of("%s")'
 
+PI_HF_FIELD_BITWIDTH = "int"
+PI_HF_FIELD_BITWIDTH_CST = "%s"
+
 PI_TBL_ID = "PiTableId"
 PI_TBL_ID_CST = 'PiTableId.of("%s")'
 
@@ -79,6 +82,7 @@ BITWIDTH_VAR_SUFFIX = "_BITWIDTH"
 class ConstantClassGenerator(object):
     headers = set()
     header_fields = set()
+    match_field_bitwidth = dict()
     tables = set()
     counters = set()
     direct_counters = set()
@@ -105,6 +109,7 @@ class ConstantClassGenerator(object):
         for tbl in p4info.tables:
             for mf in tbl.match_fields:
                 self.header_fields.add(mf.name)
+                self.match_field_bitwidth[mf.name] = mf.bitwidth
 
             self.tables.add(tbl.preamble.name)
 
@@ -143,9 +148,6 @@ class ConstantClassGenerator(object):
 
     def const_line(self, name, type, constructor, value=None):
         var_name = self.convert_camel_to_all_caps(name)
-        if type == PI_HF_FIELD_ID:
-            var_name = var_name.replace("$VALID$", "VALID")
-            var_name = HF_VAR_PREFIX + var_name
         val = constructor % (name if value is None else value,)
 
         line = CONST_FMT % (type, var_name, val)
@@ -166,7 +168,14 @@ class ConstantClassGenerator(object):
         if len(self.header_fields) != 0:
             lines.append("    // Header field IDs")
         for hf in self.header_fields:
-            lines.append(self.const_line(hf, PI_HF_FIELD_ID, PI_HF_FIELD_ID_CST))
+            lines.append(self.const_line(HF_VAR_PREFIX + hf, PI_HF_FIELD_ID, PI_HF_FIELD_ID_CST, value=hf))
+            lines.append(self.const_line(
+                HF_VAR_PREFIX + hf + BITWIDTH_VAR_SUFFIX,
+                PI_HF_FIELD_BITWIDTH,
+                PI_HF_FIELD_BITWIDTH_CST,
+                value=self.match_field_bitwidth[hf]
+            )
+        )
 
         if len(self.tables) != 0:
             lines.append("    // Table IDs")


### PR DESCRIPTION
Note: `@name` annotation is required for `isValid()` fields from now on
To simplify the generation logic, this patch removes the part of code that
automatically converts `$VALID$` to `VALID`