### PR TITLE
SDFAB-405 Generate port shaping config in QoS config script

### DIFF
--- a/util/gen-stratum-qos-config.py
+++ b/util/gen-stratum-qos-config.py
@@ -300,7 +300,8 @@ def queue_config(
     el_min_rates_bps.append(BE_MIN_RATE_BPS)
 
     # Compute WRR scheduling weights to distribute the available bandwidth.
-    el_wrr_weights = [ceil(1023 * x / sum(el_min_rates_bps)) for x in el_min_rates_bps]
+    el_norm_weights = [x / sum(el_min_rates_bps) for x in el_min_rates_bps]
+    el_wrr_weights = [ceil(1023 * x) for x in el_norm_weights]
 
     # As before, set base_use_limit proportionally to the queue maximum rate. In this case, the
     # queue maximum rate is not enforced through shaping (hence it is not the same for all ports),
@@ -341,7 +342,7 @@ def queue_config(
             queue_id = next_queue_id
             next_queue_id += 1
         queue_mappings[queue_id] = queue_mapping(
-            descr=f"{name} ({format_bps(el_min_rates_bps[i])})",
+            descr=f"{name} ({el_norm_weights[i]:.1%}, gmin {format_bps(el_norm_weights[i] * el_avail_bw_bps)})",
             queue_id=queue_id,
             app_pool=app_pool,
             prio=EL_PRIORITY,
@@ -391,6 +392,26 @@ def pool_config(descr, pool, size, enable_color_drop, limit_yellow=0, limit_red=
         }}"""
 
 
+def port_shaping_config(descr, port_id, rate_bps, burst_bytes):
+    """
+    Returns a per_port_shaping_configs blob with the given parameters.
+    :param descr: port description
+    :param rate_bps: SingletonPort ID form Stratum's chassis_config
+    :param rate_bps: shaping rate in bps
+    :param burst_bytes: burst_size in bytes
+    :return:
+    """
+    return f"""        per_port_shaping_configs {{
+          key: {port_id} # {descr}
+          value {{
+            byte_shaping {{
+              rate_bps: {rate_bps} # {format_bps(rate_bps)}
+              burst_bytes: {burst_bytes}
+            }}
+          }}
+        }}"""
+
+
 def vendor_config(yaml_config):
     """
     Returns a vendor_config blob
@@ -423,6 +444,8 @@ def vendor_config(yaml_config):
         pool_sizes=pool_sizes,
     )
 
+    shaping_blobs = []
+
     port_templates = []
     for port_template in yaml_config["port_templates"]:
         temp = dict(
@@ -435,15 +458,23 @@ def vendor_config(yaml_config):
                 temp['port_id'] = port_id
                 temp['sdk_port_id'] = None
                 port_templates.append(temp)
+                # Shaping can only be applied to front-panel ports,
+                # it doesn't make sense to shape internal ports.
+                if port_template['is_shaping_enabled']:
+                    shaping_blobs.append(port_shaping_config(
+                        descr=port_template["descr"],
+                        port_id=port_id,
+                        rate_bps=port_template['rate_bps'],
+                        burst_bytes=port_template['shaping_burst_bytes']))
         if "sdk_port_ids" in port_template:
             for sdk_port_id in port_template["sdk_port_ids"]:
                 temp['port_id'] = None
                 temp['sdk_port_id'] = sdk_port_id
                 port_templates.append(temp)
 
-    blobs = []
+    queue_blobs = []
 
-    blobs.append(
+    queue_blobs.append(
         pool_config(
             descr=f"Control ({pool_allocations[CT_APP_POOL]}%)",
             pool=CT_APP_POOL,
@@ -452,7 +483,7 @@ def vendor_config(yaml_config):
         )
     )
 
-    blobs.append(
+    queue_blobs.append(
         pool_config(
             descr=f"Real-Time ({pool_allocations[RT_APP_POOL]}%)",
             pool=RT_APP_POOL,
@@ -463,7 +494,7 @@ def vendor_config(yaml_config):
         )
     )
 
-    blobs.append(
+    queue_blobs.append(
         pool_config(
             descr=f"Elastic ({pool_allocations[EL_APP_POOL]}%)",
             pool=EL_APP_POOL,
@@ -474,7 +505,7 @@ def vendor_config(yaml_config):
         )
     )
 
-    blobs.append(
+    queue_blobs.append(
         pool_config(
             descr=f"Best-Effort ({pool_allocations[BE_APP_POOL]}%)",
             pool=BE_APP_POOL,
@@ -486,7 +517,7 @@ def vendor_config(yaml_config):
     )
 
     for port in port_templates:
-        blobs.append(
+        queue_blobs.append(
             queue_config(
                 **port,
                 port_rates_bps=[x["port_rate_bps"] for x in port_templates],
@@ -508,9 +539,14 @@ def vendor_config(yaml_config):
 
     return f"""vendor_config {{
   tofino_config {{
+    node_id_to_port_shaping_config {{
+      key: 1 
+      value {{\n{NEW_LINE.join(shaping_blobs)}
+      }}
+    }}
     node_id_to_qos_config {{
       key: 1
-      value {{\n{NEW_LINE.join(blobs)}
+      value {{\n{NEW_LINE.join(queue_blobs)}
       }}
     }}
   }}

--- a/util/sample-qos-config.yml
+++ b/util/sample-qos-config.yml
@@ -48,25 +48,26 @@ elastic_min_rates_bps:
 # - descr: description of the port purpose
 # - rate_bps: port speed in bps
 # - is_shaping_enabled: true if rate is enforced using shaping, false if it is the channel speed.
-#     TODO: implement shaping configuration
+# - shaping_burst_bytes: burst size in bytes, meaningful only if port is shaped.
 # - queue_count: number of queues assigned to the port
 # - port_ids: list of Stratum port IDs with this template (SingletonPort ID from chassis_config)
 # - sdk_port_ids: list of SDK port numbers (Tofino DP_ID) with this template (used for internal ports, e.g., recirculation)
 port_templates:
-  - descr: Base station
+  - descr: "Base station"
     rate_bps: 1000000000 # 1 Gbps
-    is_shaping_enabled: false
+    is_shaping_enabled: true
+    shaping_burst_bytes: 18000 # 2x jumbo frames
     queue_count: 16
     port_ids:
       - 100
-  - descr: Servers
+  - descr: "Servers"
     port_ids:
       - 200
       - 300
     rate_bps: 40000000000 # 40 Gbps
     is_shaping_enabled: false
     queue_count: 16
-  - descr: Recirculation
+  - descr: "Recirculation"
     sdk_port_ids:
       - 68
       - 196


### PR DESCRIPTION
This change allows using `gen-stratum-qos-config.py` to generate a complete `vendor_config` blob including both queue config and port shaping config. Such `vendor_config` can be appended to an existing chassis_config file. This is required to support generation of chassis_configs during linerate tests (SDFAB-404) to allow testing with different queue parameters, e.g. testing the behavior of WRR scheduling when suing different port shaping rates and weights.

Also, we sneak in a small and unrelated change to the description of elastic queues: instead of printing the requested minimum rate, we print the percentage of link bandwidth and the corresponding gmin rate when higher priority queues are unused. This simplifies the validation of WRR tests.