### PR TITLE
[WIP] Add stateful linerate test

### DIFF
--- a/ptf/tests/common/ptf_runner.py
+++ b/ptf/tests/common/ptf_runner.py
@@ -231,7 +231,9 @@ def set_up_trex_server(trex_daemon_client, trex_address, trex_config, force_rest
             return False
 
         trex_config_file_on_server = TREX_FILES_DIR + os.path.basename(trex_config)
-        trex_daemon_client.start_stateless(cfg=trex_config_file_on_server)
+        # trex_daemon_client.start_stateless(cfg=trex_config_file_on_server)
+        trex_daemon_client.start_stateless(cfg=trex_config_file_on_server, astf=True)
+        # trex_daemon_client.start_trex(f="/dev/null", d=30, cfg=trex_config_file_on_server, astf=True)
     except ConnectionRefusedError:
         error(
             "Unable to connect to server %s.\n" + "Did you start the Trex daemon?",
@@ -489,7 +491,9 @@ def main():
 
     # if line rate test, set up and tear down TRex
     if args.trex_address is not None:
-        trex_daemon_client = CTRexClient(args.trex_address)
+        # not needed, maybe
+        trex_args = None #"--astf"
+        trex_daemon_client = CTRexClient(args.trex_address, trex_args=trex_args)
         info("Starting TRex daemon client...")
         success = set_up_trex_server(
             trex_daemon_client, args.trex_address, args.trex_config, args.force_restart

--- a/ptf/tests/common/trex_test.py
+++ b/ptf/tests/common/trex_test.py
@@ -3,6 +3,7 @@
 
 from base_test import *
 from trex.stl.api import STLClient
+from trex.astf.trex_astf_client import ASTFClient
 
 
 class TRexTest(P4RuntimeTest):
@@ -28,3 +29,28 @@ class TRexTest(P4RuntimeTest):
         self.trex_client.release()
         self.trex_client.disconnect()
         super(TRexTest, self).tearDown()
+
+
+class TRexStatefulTest(P4RuntimeTest):
+    trex_client: ASTFClient
+
+    def setUp(self):
+        super(TRexStatefulTest, self).setUp()
+        trex_server_addr = ptf.testutils.test_param_get("trex_server_addr")
+        self.trex_client = ASTFClient(server=trex_server_addr)
+        self.trex_client.connect()
+        self.trex_client.acquire()
+        self.trex_client.reset()  # Resets configs from all ports
+        self.trex_client.clear_stats()  # Clear status from all ports
+        # Put all ports to promiscuous mode, otherwise they will drop all
+        # incoming packets if the destination mac is not the port mac address.
+        self.trex_client.set_port_attr(
+            self.trex_client.get_all_ports(), promiscuous=True
+        )
+
+    def tearDown(self):
+        print("Tearing down ASTFClient...")
+        self.trex_client.stop()
+        self.trex_client.release()
+        self.trex_client.disconnect()
+        super(TRexStatefulTest, self).tearDown()


### PR DESCRIPTION
This PR adds a stateful linerate test.


Example output:

```
  qos_tests.StatefulTest ... {'global': {'active_flows': 0.0,
            'active_sockets': 0,
            'bw_per_core': 0.12813211977481842,
            'cpu_util': 0.20416809618473053,
            'cpu_util_raw': 0.0,
            'open_flows': 5008.0,
            'platform_factor': 1.0,
            'rx_bps': 3659770.25,
            'rx_core_pps': 1992.5047607421875,
            'rx_cpu_util': 0.07341904938220978,
            'rx_drop_bps': 525908.25,
            'rx_pps': 6471.4794921875,
            'socket_util': 0.0,
            'tx_expected_bps': 0.0,
            'tx_expected_cps': 0.0,
            'tx_expected_pps': 0.0,
            'tx_pps': 7467.5107421875,
            'tx_bps': 4185678.5,
            'tx_cps': 496.7500305175781,
            'total_servers': 0,
            'total_clients': 0,
            'total_alloc_error': 0,
            'queue_full': 0},
 0: {'opackets': 35778,
     'ipackets': 30728,
     'obytes': 2531620,
     'ibytes': 2163264,
     'oerrors': 0,
     'ierrors': 0,
     'tx_bps': 1975392.75,
     'tx_pps': 3484.928466796875,
     'tx_bps_L1': 2532981.3046875,
     'tx_util': 0.00633245326171875,
     'rx_bps': 1684511.125,
     'rx_pps': 2986.79345703125,
     'rx_bps_L1': 2162398.078125,
     'rx_util': 0.0054059951953125},
 1: {'opackets': 30728,
     'ipackets': 35778,
     'obytes': 2163264,
     'ibytes': 2531620,
     'oerrors': 0,
     'ierrors': 0,
     'tx_bps': 1684477.625,
     'tx_pps': 2986.7333984375,
     'tx_bps_L1': 2162354.96875,
     'tx_util': 0.005405887421875,
     'rx_bps': 1975259.125,
     'rx_pps': 3484.685791015625,
     'rx_bps_L1': 2532808.8515625,
     'rx_util': 0.00633202212890625},
 2: {'opackets': 10738,
     'ipackets': 0,
     'obytes': 708708,
     'ibytes': 0,
     'oerrors': 0,
     'ierrors': 0,
     'tx_bps': 525808.125,
     'tx_pps': 995.8487548828125,
     'tx_bps_L1': 685143.92578125,
     'tx_util': 0.001712859814453125,
     'rx_bps': 0.0,
     'rx_pps': 0.0,
     'rx_bps_L1': 0,
     'rx_util': 0.0},
 3: {'opackets': 0,
     'ipackets': 0,
     'obytes': 0,
     'ibytes': 0,
     'oerrors': 0,
     'ierrors': 0,
     'tx_bps': 0.0,
     'tx_pps': 0.0,
     'tx_bps_L1': 0,
     'tx_util': 0.0,
     'rx_bps': 0.0,
     'rx_pps': 0.0,
     'rx_bps_L1': 0,
     'rx_util': 0.0},
 'total': {'opackets': 77244,
           'ipackets': 66506,
           'obytes': 5403592,
           'ibytes': 4694884,
           'oerrors': 0,
           'ierrors': 0,
           'tx_bps': 4185678.5,
           'tx_pps': 7467.5106201171875,
           'tx_bps_L1': 5380480.19921875,
           'tx_util': 0.013451200498046876,
           'rx_bps': 3659770.25,
           'rx_pps': 6471.479248046875,
           'rx_bps_L1': 4695206.9296875,
           'rx_util': 0.011738017324218749},
 'traffic': {'client': {'m_active_flows': 0,
                        'm_est_flows': 0,
                        'm_tx_bw_l7_r': 17983.63078241005,
                        'm_tx_bw_l7_total_r': 17966.458452312963,
                        'm_rx_bw_l7_r': 8985.75367647059,
                        'm_tx_pps_r': 1871.35595703125,
                        'm_rx_pps_r': 1874.032958984375,
                        'm_avg_size': 0.9000862481716214,
                        'm_tx_ratio': 100.09557993937796,
                        'm_traffic_duration': 10.591256533636363,
                        'tcps_connattempt': 5008,
                        'tcps_connects': 5008,
                        'tcps_closed': 5008,
                        'tcps_segstimed': 20032,
                        'tcps_rttupdated': 20032,
                        'tcps_sndtotal': 25040,
                        'tcps_sndpack': 10016,
                        'tcps_sndbyte': 30048,
                        'tcps_sndbyte_ok': 30048,
                        'tcps_sndctrl': 5008,
                        'tcps_sndacks': 10016,
                        'tcps_rcvpack': 10016,
                        'tcps_rcvbyte': 15024,
                        'tcps_rcvackpack': 15024,
                        'tcps_rcvackbyte': 30048,
                        'tcps_rcvackbyte_of': 5008},
             'server': {'m_active_flows': 0,
                        'm_est_flows': 0,
                        'm_tx_bw_l7_r': 8992.35526127927,
                        'm_tx_bw_l7_total_r': 8979.962342946887,
                        'm_rx_bw_l7_r': 17977.005996573385,
                        'm_tx_pps_r': 1497.87451171875,
                        'm_rx_pps_r': 2248.13232421875,
                        'm_avg_size': 0.8999370008858756,
                        'm_tx_ratio': 100.1380063507963,
                        'm_traffic_duration': 10.586901838181818,
                        'tcps_accepts': 5008,
                        'tcps_connects': 5008,
                        'tcps_closed': 5008,
                        'tcps_segstimed': 15024,
                        'tcps_rttupdated': 15024,
                        'tcps_sndtotal': 20032,
                        'tcps_sndpack': 5008,
                        'tcps_sndbyte': 15024,
                        'tcps_sndbyte_ok': 15024,
                        'tcps_sndacks': 15024,
                        'tcps_rcvpack': 15024,
                        'tcps_rcvbyte': 30048,
                        'tcps_rcvackpack': 15024,
                        'tcps_rcvackbyte': 15024,
                        'tcps_rcvackbyte_of': 10016,
                        'tcps_preddat': 5008}},
 'latency': {0: {'hist': {'cnt': 10604,
                          'high_cnt': 1,
                          'histogram': [{'key': 10, 'val': 1}],
                          'max_usec': 18,
                          'min_usec': 10,
                          's_avg': 4.0,
                          's_max': 5.934545},
                 'stats': {'ignore_bytes': 0,
                           'ipv6_n_solic': 0,
                           'm_jitter': 0,
                           'm_l3_cs_err': 0,
                           'm_l4_cs_err': 0,
                           'm_length_error': 0,
                           'm_no_id': 0,
                           'm_no_ipv4_option': 0,
                           'm_no_magic': 0,
                           'm_pkt_ok': 10696,
                           'm_rx_check': 0,
                           'm_seq_error': 0,
                           'm_tx_pkt_err': 0,
                           'm_tx_pkt_ok': 10738,
                           'm_unsup_prot': 0,
                           'tx_arp': 0}},
             1: {'hist': {'cnt': 10646,
                          'high_cnt': 42,
                          'histogram': [{'key': 10, 'val': 25},
                                        {'key': 20, 'val': 16},
                                        {'key': 30, 'val': 1}],
                          'max_usec': 19,
                          'min_usec': 10,
                          's_avg': 5.0,
                          's_max': 6.207273},
                 'stats': {'ignore_bytes': 0,
                           'ipv6_n_solic': 0,
                           'm_jitter': 0,
                           'm_l3_cs_err': 0,
                           'm_l4_cs_err': 0,
                           'm_length_error': 0,
                           'm_no_id': 0,
                           'm_no_ipv4_option': 0,
                           'm_no_magic': 0,
                           'm_pkt_ok': 10738,
                           'm_rx_check': 0,
                           'm_seq_error': 0,
                           'm_tx_pkt_err': 0,
                           'm_tx_pkt_ok': 10696,
                           'm_unsup_prot': 0,
                           'tx_arp': 0}},
             2: {'hist': {'cnt': 0,
                          'high_cnt': 0,
                          'histogram': [],
                          'max_usec': 0,
                          'min_usec': 10,
                          's_avg': 0.0,
                          's_max': 0.0},
                 'stats': {'ignore_bytes': 0,
                           'ipv6_n_solic': 0,
                           'm_jitter': 0,
                           'm_l3_cs_err': 0,
                           'm_l4_cs_err': 0,
                           'm_length_error': 0,
                           'm_no_id': 0,
                           'm_no_ipv4_option': 0,
                           'm_no_magic': 0,
                           'm_pkt_ok': 0,
                           'm_rx_check': 0,
                           'm_seq_error': 0,
                           'm_tx_pkt_err': 0,
                           'm_tx_pkt_ok': 10738,
                           'm_unsup_prot': 0,
                           'tx_arp': 0}},
             3: {'hist': {'cnt': 0,
                          'high_cnt': 0,
                          'histogram': [],
                          'max_usec': 0,
                          'min_usec': 10,
                          's_avg': 0.0,
                          's_max': 0.0},
                 'stats': {'ignore_bytes': 0,
                           'ipv6_n_solic': 0,
                           'm_jitter': 0,
                           'm_l3_cs_err': 0,
                           'm_l4_cs_err': 0,
                           'm_length_error': 0,
                           'm_no_id': 0,
                           'm_no_ipv4_option': 0,
                           'm_no_magic': 0,
                           'm_pkt_ok': 0,
                           'm_rx_check': 0,
                           'm_seq_error': 0,
                           'm_tx_pkt_err': 0,
                           'm_tx_pkt_ok': 0,
                           'm_unsup_prot': 0,
                           'tx_arp': 0}}}}
```