### PR TITLE
Fix duplicate `queue_configs` with same port ID

### DIFF
--- a/util/gen-stratum-qos-config.py
+++ b/util/gen-stratum-qos-config.py
@@ -453,7 +453,7 @@ def vendor_config(yaml_config):
             for port_id in port_template["port_ids"]:
                 temp["port_id"] = port_id
                 temp["is_sdk_port"] = False
-                port_templates.append(temp)
+                port_templates.append(temp.copy())
                 # Shaping can only be applied to front-panel ports,
                 # it doesn't make sense to shape internal ports.
                 if port_template["is_shaping_enabled"]:
@@ -469,7 +469,7 @@ def vendor_config(yaml_config):
             for sdk_port_id in port_template["sdk_port_ids"]:
                 temp["port_id"] = sdk_port_id
                 temp["is_sdk_port"] = True
-                port_templates.append(temp)
+                port_templates.append(temp.copy())
 
     queue_blobs = []
 


### PR DESCRIPTION
This issue was causing duplicate `queue_configs` with the same `port` ID as the last one in the `port_ids` list of the `port_templates`. To clarify with an example, given the following `port_templates` section:
```
port_templates:
-  descr: "Servers"
   port_ids:
    - 200
    - 300
   rate_bps: 40000000000 # 40 Gbps
   is_shaping_enabled: false
   queue_count: 16
```
The QoS config will miss the `queue_configs` for port_id 200, but will have duplicate port configs for port 300.
