### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ To use ONOS to control a Tofino switch, you will need to run the
 * ONOS >= 2.5.1
 * Docker (to run the build scripts without worrying about dependencies)
 * cURL (to interact with the ONOS REST APIs)
-* ip (to 
 
 ### Barefoot SDE Docker Image
 


### PR DESCRIPTION
Hi,
I had some problems while going through the README.md, trying to run the PTF tests;
The correct docker image should be `bf-sde:9.5.0-tm`, since the 9.5.0 doesn't have the tool `ip`; for this reason, the script _veth_setup.sh_ fails silently and the container exits without showing any log.