### PR TITLE
Fix Jenkins linerate test job permissions issue when attempting to mount `/tmp` from container

### DIFF
--- a/ptf/run/hw/base.sh
+++ b/ptf/run/hw/base.sh
@@ -32,16 +32,24 @@ P4C_OUT=p4src/tna/build/${fabricProfile}/sde_${sdeVer_}
 echo "*** Using P4 compiler output in ${P4C_OUT}..."
 
 testerRunName=tester-${RANDOM}
+function stop() {
+    set +e
+    echo "*** Stopping ${testerRunName}..."
+    docker stop -t0 ${testerRunName} > /dev/null 2>&1
+    docker cp ${testerRunName}:/tmp/. "${DIR}"/log > /dev/null 2>&1
+    docker rm ${testerRunName} > /dev/null 2>&1
+}
+trap stop EXIT
+
 echo "*** Starting ${testerRunName}..."
 # Do not attach stdin if running in an environment without it (e.g., Jenkins)
 it=$(test -t 0 && echo "-it" || echo "-t")
 # shellcheck disable=SC2068
 # mount localtime to container so test pcap time in name matches machine's local time
-docker run --name "${testerRunName}" "${it}" --rm \
+docker run --name "${testerRunName}" "${it}" \
     --network host \
     --privileged \
     -v "${FABRIC_TNA_ROOT}":/fabric-tna \
-    -v "${DIR}/log":/tmp \
     -v /etc/localtime:/etc/localtime \
     -e P4C_OUT="${P4C_OUT}" \
     -e PTF_FILTER="${PTF_FILTER}" \


### PR DESCRIPTION
Errors have been encountered in the past with permissions issues for the Jenkins linerate test job regarding the original method of mounting the `/tmp` directory from the container back into `ptf/run/hw/log` once the tests have been completed. 

Here, we change the `base.sh` file to replicate the current behaviour of `ptf/run/tm/base.sh`. At the end of the file, we instead copy all files from the Docker container's `/tmp` over to `ptf/run/hw/log`, then remove the container.