### PR TITLE
Handle special case for INT queue report config

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/inbandtelemetry/IntReportConfig.java
+++ b/src/main/java/org/stratumproject/fabric/tna/inbandtelemetry/IntReportConfig.java
@@ -153,8 +153,11 @@ public class IntReportConfig extends Config<ApplicationId> {
                 ObjectNode threshold = JsonUtils.node(thresholds, queueIdStr);
                 if (threshold.hasNonNull(RESET_NS)) {
                     return (long) JsonUtils.number(threshold, RESET_NS);
-                } else {
+                } else if (threshold.hasNonNull(TRIGGER_NS)) {
                     return queueReportTriggerLatencyThresholdNs(queueId) / 2;
+                } else {
+                    // Both tiggerNs and resetNs are not present.
+                    return DEFAULT_QUEUE_REPORT_RESET_LATENCY_THRESHOLD;
                 }
             } else {
                 return DEFAULT_QUEUE_REPORT_RESET_LATENCY_THRESHOLD;

--- a/src/test/resources/int-report-queue-report-threshold.json
+++ b/src/test/resources/int-report-queue-report-threshold.json
@@ -5,6 +5,7 @@
     "watchSubnets": [],
     "queueReportLatencyThresholds": {
         "0": {"triggerNs": 1888, "resetNs": 388},
-        "7": {"triggerNs": 500}
+        "7": {"triggerNs": 500},
+        "8": {"_comment_": "Never trigger report or reset quota."}
     }
 }


### PR DESCRIPTION
Consider the following case:

```json
"queueReportLatencyThresholds": {
  "0": {}
}
```

In the current implementation this will make the trigger threshold become
`0xffffffff`(Never trigger) and reset threshold become `0x7fffffff`(Will be
reset in most case...).

I believed we should treat this case like we don't put any config for
this queue, the result for this case should be equivalent to:

```json
"queueReportLatencyThresholds": {
}
```