### PR TITLE
Revert "Increase UPF table size to handle up to 100k tunnels per direction"

### DIFF
--- a/p4src/shared/size.p4
+++ b/p4src/shared/size.p4
@@ -32,13 +32,12 @@
 #define INT_QUEUE_REPORT_TABLE_SIZE 32 * 4
 
 // Constants for the SPGW control block.
-#define NUM_UES 100000
+#define NUM_UES 10240
 // We expect between 4 and 8 tunnels per UE.
 #define MAX_GTP_TUNNELS_PER_UE 1
 #define NUM_GTP_TUNNLES (NUM_UES * MAX_GTP_TUNNELS_PER_UE)
-// Not all PDRs can have a counter. It's up to the control plane to decide when
-// to allocate counters.
-#define MAX_PDR_COUNTERS 4096
+// One counter for down and uplink direction.
+#define MAX_PDR_COUNTERS (2 * NUM_GTP_TUNNLES)
 #define NUM_UPLINK_PDRS NUM_GTP_TUNNLES
 #define NUM_DOWNLINK_PDRS NUM_GTP_TUNNLES
 // One table entry per down and uplink direction.


### PR DESCRIPTION
This reverts commit 63e84d0dff155689d34090885783de5f1076fa5c.