### PR TITLE
[SDFAB-721] Custom traffic highlights stop working after instance restart

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/stats/HighlightManager.java
+++ b/src/main/java/org/stratumproject/fabric/tna/stats/HighlightManager.java
@@ -106,6 +106,9 @@ public class HighlightManager implements HighlightService {
         uiExtensionService.register(trafficFactory);
         uiExtensionService.register(allFactory);
 
+        // bootstrap the internal highlighters
+        highLightExecutor.submit(this::bootstrapHighlighters);
+
         log.info("Started");
     }
 
@@ -126,6 +129,15 @@ public class HighlightManager implements HighlightService {
         uiExtensionService.unregister(allFactory);
 
         log.info("Stopped");
+    }
+
+    private void bootstrapHighlighters() {
+        log.debug("Bootstrap the highlighters");
+        highlightStore.forEach(highlightKey -> {
+            nameHighlighter.addHighlighter(highlightKey);
+            trafficHighlighter.addHighlighter(highlightKey);
+            allHighlighter.addHighlighter(highlightKey);
+        });
     }
 
     @Override

--- a/src/main/java/org/stratumproject/fabric/tna/stats/StatisticManager.java
+++ b/src/main/java/org/stratumproject/fabric/tna/stats/StatisticManager.java
@@ -287,6 +287,14 @@ public class StatisticManager implements StatisticService {
     protected class InternalStatsCollector implements Runnable {
         @Override
         public void run() {
+            try {
+                updateStats();
+            } catch (Exception e) {
+                log.error("Error during stats update: {}", e.getMessage());
+            }
+        }
+
+        private void updateStats() {
             flowRuleService.getFlowEntriesById(appId).forEach(flowEntry -> {
                 TrafficSelector flowSelector = flowEntry.selector();
 


### PR DESCRIPTION
The patch contains the following:

- Prevent the ejection of the stats collector in the healthy instances.
- Bootstrap the highlights in the activate method if the highlightsStore is not empty

The first issue can easily happen due to connection rejected/timeout in the FlowRuleStore.
Regarding the second issue, the highlights are populated only upon primitive events and
the restarted instance will not get those again during the startup (this happens only for
gossip based primitives)