### PR TITLE
[SDFAB-747] Add SIGINT signal handle to close TRex before force quitting linerate tests

### DIFF
--- a/ptf/run/hw/linerate
+++ b/ptf/run/hw/linerate
@@ -7,8 +7,7 @@ FABRIC_TNA_ROOT="${DIR}"/../../..
 # shellcheck source=.env
 source "${FABRIC_TNA_ROOT}"/.env
 export TREX_PARAMS="${TREX_PARAMS:-} --trex-address ${TREX_ADDR} \
-                    --trex-config /fabric-tna/ptf/run/hw/trex-config/4-ports-with-l2.yaml \
-                    --trex-force-restart"
+                    --trex-config /fabric-tna/ptf/run/hw/trex-config/4-ports-with-l2.yaml"
 export PORT_MAP="/fabric-tna/ptf/run/hw/port_map.trex.json"
 export PTF_DIR="/fabric-tna/ptf/tests/linerate"
 export PTF_FILTER="${PTF_FILTER:-} ^trex-sw-mode"


### PR DESCRIPTION
Handles SIGINT to close TRex processes before exiting when force-quitting linerate tests.