### PR TITLE
Fix punt and copy to cpu actions to non-post_ingress actions.

### DIFF
--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/ForwardingObjectiveTranslator.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/pipeliner/ForwardingObjectiveTranslator.java
@@ -256,12 +256,12 @@ class ForwardingObjectiveTranslator
                 final PiAction aclAction;
                 if (treatment.clearedDeferred()) {
                     aclAction = PiAction.builder()
-                            .withId(P4InfoConstants.FABRIC_INGRESS_ACL_PUNT_TO_CPU_POST_INGRESS)
+                            .withId(P4InfoConstants.FABRIC_INGRESS_ACL_PUNT_TO_CPU)
                             .build();
                 } else {
                     // Action is COPY_TO_CPU
                     aclAction = PiAction.builder()
-                            .withId(P4InfoConstants.FABRIC_INGRESS_ACL_COPY_TO_CPU_POST_INGRESS)
+                            .withId(P4InfoConstants.FABRIC_INGRESS_ACL_COPY_TO_CPU)
                             .build();
                 }
                 final TrafficTreatment piTreatment = DefaultTrafficTreatment.builder()

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/ForwardingObjectiveTranslatorTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/pipeliner/ForwardingObjectiveTranslatorTest.java
@@ -78,7 +78,7 @@ public class ForwardingObjectiveTranslatorTest extends AbstractObjectiveTranslat
 
         FlowRule actualFlowRule = flowRulesInstalled.get(0);
         PiAction piAction = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_INGRESS_ACL_COPY_TO_CPU_POST_INGRESS)
+                .withId(P4InfoConstants.FABRIC_INGRESS_ACL_COPY_TO_CPU)
                 .build();
         FlowRule expectedFlowRule = DefaultFlowRule.builder()
                 .forDevice(DEVICE_ID)
@@ -128,7 +128,7 @@ public class ForwardingObjectiveTranslatorTest extends AbstractObjectiveTranslat
 
         FlowRule actualFlowRule = flowRulesInstalled.get(0);
         PiAction piAction = PiAction.builder()
-                .withId(P4InfoConstants.FABRIC_INGRESS_ACL_PUNT_TO_CPU_POST_INGRESS)
+                .withId(P4InfoConstants.FABRIC_INGRESS_ACL_PUNT_TO_CPU)
                 .build();
         FlowRule expectedFlowRule = DefaultFlowRule.builder()
                 .forDevice(DEVICE_ID)


### PR DESCRIPTION
This PR aims to fix the `punt` and `copy` to CPU actions from `*_POST_INGRESS` to non-`*_POST_INGRESS`.
The `*_post_ingress` actions were introduced in #264

We don't want the post_ingress because `copy`/`punt` should copy/punt packets to the CPU without the changes done in the ingress pipeline.