### PR TITLE
PTF hangs when getting batch of success and fail write response

### DIFF
--- a/ptf/tests/common/base_test.py
+++ b/ptf/tests/common/base_test.py
@@ -179,6 +179,7 @@ class P4RuntimeErrorIterator:
                     "Cannot convert Any message to p4.Error"
                 )
             if p4_error.canonical_code == code_pb2.OK:
+                self.idx += 1
                 continue
             v = self.idx, p4_error
             self.idx += 1


### PR DESCRIPTION
When receiving a batch of errors with mixed OK code and error code, the test will hand due to the infinity loop in the P4RuntimeErrorIterator since we are not increasing the index of the error array