### PR TITLE
Add timeout to Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
         label "${params.buildNode}"
     }
     options {
-        timeout(time: 80, unit: 'MINUTES')
+        timeout(time: 1, unit: 'HOURS')
     }
     stages {
         stage("Prepare environment") {


### PR DESCRIPTION
Jenkins, while using declarative pipelines, expects the timeout to be declared within the Jenkinsfile. The value on JJB is not considered.

- [x] Add timeout in Jenkinsfile
- [x] Clean the JJB template (https://gerrit.onosproject.org/c/ci-management/+/25175)