### PR TITLE
[SDFAB-880] Add support for not specifying TC

### DIFF
--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslatorTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslatorTest.java
@@ -96,6 +96,38 @@ public class FabricUpfTranslatorTest {
     }
 
     @Test
+    public void fabricEntryToUplinkUpfTerminationNoTcTest() {
+        UpfTerminationUplink translatedUpfTerminationRule;
+        UpfTerminationUplink expected = TestUpfConstants.UPLINK_UPF_TERMINATION_NO_TC;
+        try {
+            translatedUpfTerminationRule = upfTranslator
+                    .fabricEntryToUpfTerminationUplink(TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_NO_TC);
+        } catch (UpfProgrammableException e) {
+            assertThat("Fabric uplink UPF termination rule should correctly " +
+                               "translate to abstract UPF termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedUpfTerminationRule, equalTo(expected));
+    }
+
+    @Test
+    public void fabricEntryToUplinkUpfTerminationDropTest() {
+        UpfTerminationUplink translatedUpfTerminationRule;
+        UpfTerminationUplink expected = TestUpfConstants.UPLINK_UPF_TERMINATION_DROP;
+        try {
+            translatedUpfTerminationRule = upfTranslator
+                    .fabricEntryToUpfTerminationUplink(TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_DROP);
+        } catch (UpfProgrammableException e) {
+            assertThat("Fabric uplink UPF termination rule should correctly " +
+                               "translate to abstract UPF termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedUpfTerminationRule, equalTo(expected));
+    }
+
+    @Test
     public void fabricEntryToDownlinkUpfTerminationTest() {
         UpfTerminationDownlink translatedUpfTerminationRule;
         UpfTerminationDownlink expected = TestUpfConstants.DOWNLINK_UPF_TERMINATION;
@@ -111,6 +143,37 @@ public class FabricUpfTranslatorTest {
         assertThat(translatedUpfTerminationRule, equalTo(expected));
     }
 
+    @Test
+    public void fabricEntryToDownlinkUpfTerminationNoTcTest() {
+        UpfTerminationDownlink translatedUpfTerminationRule;
+        UpfTerminationDownlink expected = TestUpfConstants.DOWNLINK_UPF_TERMINATION_NO_TC;
+        try {
+            translatedUpfTerminationRule = upfTranslator
+                    .fabricEntryToUpfTerminationDownlink(TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC);
+        } catch (UpfProgrammableException e) {
+            assertThat("Fabric downlink UPF termination rule should correctly " +
+                               "translate to abstract UPF termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedUpfTerminationRule, equalTo(expected));
+    }
+
+    @Test
+    public void fabricEntryToDownlinkUpfTerminationDropTest() {
+        UpfTerminationDownlink translatedUpfTerminationRule;
+        UpfTerminationDownlink expected = TestUpfConstants.DOWNLINK_UPF_TERMINATION_DROP;
+        try {
+            translatedUpfTerminationRule = upfTranslator
+                    .fabricEntryToUpfTerminationDownlink(TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_DROP);
+        } catch (UpfProgrammableException e) {
+            assertThat("Fabric downlink UPF termination rule should correctly " +
+                               "translate to abstract UPF termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedUpfTerminationRule, equalTo(expected));
+    }
 
     @Test
     public void fabricEntryToUplinkInterfaceTest() {
@@ -280,12 +343,92 @@ public class FabricUpfTranslatorTest {
     }
 
     @Test
+    public void uplinkUpfTerminationNoTcToFabricEntryTest() {
+        FlowRule translatedRule;
+        FlowRule expectedRule = TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_NO_TC;
+        try {
+            translatedRule = upfTranslator.upfTerminationUplinkToFabricEntry(
+                    TestUpfConstants.UPLINK_UPF_TERMINATION_NO_TC,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID,
+                    TestUpfConstants.DEFAULT_PRIORITY);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract uplink UPF Termination should correctly " +
+                               "translate to Fabric UPF Termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedRule, equalTo(expectedRule));
+        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
+    }
+
+    @Test
+    public void uplinkUpfTerminationDropToFabricEntryTest() {
+        FlowRule translatedRule;
+        FlowRule expectedRule = TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_DROP;
+        try {
+            translatedRule = upfTranslator.upfTerminationUplinkToFabricEntry(
+                    TestUpfConstants.UPLINK_UPF_TERMINATION_DROP,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID,
+                    TestUpfConstants.DEFAULT_PRIORITY);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract uplink UPF Termination should correctly " +
+                               "translate to Fabric UPF Termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedRule, equalTo(expectedRule));
+        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
+    }
+
+    @Test
     public void downlinkUpfTerminationToFabricEntryTest() {
         FlowRule translatedRule;
         FlowRule expectedRule = TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION;
         try {
             translatedRule = upfTranslator.upfTerminationDownlinkToFabricEntry(
                     TestUpfConstants.DOWNLINK_UPF_TERMINATION,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID,
+                    TestUpfConstants.DEFAULT_PRIORITY);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract downlink UPF Termination should correctly " +
+                               "translate to Fabric UPF Termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedRule, equalTo(expectedRule));
+        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
+    }
+
+    @Test
+    public void downlinkUpfTerminationNoTcToFabricEntryTest() {
+        FlowRule translatedRule;
+        FlowRule expectedRule = TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC;
+        try {
+            translatedRule = upfTranslator.upfTerminationDownlinkToFabricEntry(
+                    TestUpfConstants.DOWNLINK_UPF_TERMINATION_NO_TC,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID,
+                    TestUpfConstants.DEFAULT_PRIORITY);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract downlink UPF Termination should correctly " +
+                               "translate to Fabric UPF Termination without error",
+                       false);
+            return;
+        }
+        assertThat(translatedRule, equalTo(expectedRule));
+        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
+    }
+
+    @Test
+    public void downlinkUpfTerminationDropToFabricEntryTest() {
+        FlowRule translatedRule;
+        FlowRule expectedRule = TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_DROP;
+        try {
+            translatedRule = upfTranslator.upfTerminationDownlinkToFabricEntry(
+                    TestUpfConstants.DOWNLINK_UPF_TERMINATION_DROP,
                     TestUpfConstants.DEVICE_ID,
                     TestUpfConstants.APP_ID,
                     TestUpfConstants.DEFAULT_PRIORITY);

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
@@ -27,7 +27,10 @@ import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.CTR_ID;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_SPGW_EG_TUNNEL_PEERS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_SPGW_LOAD_TUNNEL_PARAMS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_APP_FWD;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_APP_FWD_NO_TC;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_DOWNLINK_DROP;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_DOWNLINK_FWD_ENCAP;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_DOWNLINK_FWD_ENCAP_NO_TC;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_DOWNLINK_SESSIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_DOWNLINK_TERMINATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_IFACE_ACCESS;
@@ -38,6 +41,7 @@ import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_ING
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_SET_DOWNLINK_SESSION_BUF;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_SET_ROUTING_IPV4_DST;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_SET_UPLINK_SESSION;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_UPLINK_DROP;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_UPLINK_SESSIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_SPGW_UPLINK_TERMINATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.HDR_GTPU_IS_VALID;
@@ -118,12 +122,36 @@ public final class TestUpfConstants {
             .withTrafficClass(UPLINK_TC)
             .build();
 
+    public static final UpfTerminationUplink UPLINK_UPF_TERMINATION_NO_TC = UpfTerminationUplink.builder()
+            .withUeSessionId(UE_ADDR)
+            .withCounterId(UPLINK_COUNTER_CELL_ID)
+            .build();
+
+    public static final UpfTerminationUplink UPLINK_UPF_TERMINATION_DROP = UpfTerminationUplink.builder()
+            .withUeSessionId(UE_ADDR)
+            .withCounterId(UPLINK_COUNTER_CELL_ID)
+            .needsDropping(true)
+            .build();
+
     public static final UpfTerminationDownlink DOWNLINK_UPF_TERMINATION = UpfTerminationDownlink.builder()
             .withUeSessionId(UE_ADDR)
             .withCounterId(DOWNLINK_COUNTER_CELL_ID)
             .withTrafficClass(DOWNLINK_TC)
             .withTeid(TEID_VALUE_QOS)
             .withQfi(DOWNLINK_QFI)
+            .build();
+
+    public static final UpfTerminationDownlink DOWNLINK_UPF_TERMINATION_NO_TC = UpfTerminationDownlink.builder()
+            .withUeSessionId(UE_ADDR)
+            .withCounterId(DOWNLINK_COUNTER_CELL_ID)
+            .withTeid(TEID_VALUE_QOS)
+            .withQfi(DOWNLINK_QFI)
+            .build();
+
+    public static final UpfTerminationDownlink DOWNLINK_UPF_TERMINATION_DROP = UpfTerminationDownlink.builder()
+            .withUeSessionId(UE_ADDR)
+            .withCounterId(DOWNLINK_COUNTER_CELL_ID)
+            .needsDropping(true)
             .build();
 
     // TODO: what about GtpTunnelPeer?
@@ -234,6 +262,42 @@ public final class TestUpfConstants {
             .withPriority(DEFAULT_PRIORITY)
             .build();
 
+    public static final FlowRule FABRIC_UPLINK_UPF_TERMINATION_NO_TC = DefaultFlowRule.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
+            .forTable(FABRIC_INGRESS_SPGW_UPLINK_TERMINATIONS)
+            .withSelector(DefaultTrafficSelector.builder()
+                      .matchPi(PiCriterion.builder()
+                               // we don't match on slice_id, because we assume distinct UE pools per slice
+                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
+                               .build()).build())
+            .withTreatment(DefaultTrafficTreatment.builder()
+                                   .piTableAction(PiAction.builder()
+                                                          .withId(FABRIC_INGRESS_SPGW_APP_FWD_NO_TC)
+                                                          .withParameters(Arrays.asList(
+                                                                  new PiActionParam(CTR_ID, UPLINK_COUNTER_CELL_ID)
+                                                          ))
+                                                          .build()).build())
+            .withPriority(DEFAULT_PRIORITY)
+            .build();
+
+    public static final FlowRule FABRIC_UPLINK_UPF_TERMINATION_DROP = DefaultFlowRule.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
+            .forTable(FABRIC_INGRESS_SPGW_UPLINK_TERMINATIONS)
+            .withSelector(DefaultTrafficSelector.builder()
+                      .matchPi(PiCriterion.builder()
+                               // we don't match on slice_id, because we assume distinct UE pools per slice
+                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
+                               .build()).build())
+            .withTreatment(DefaultTrafficTreatment.builder()
+                                   .piTableAction(PiAction.builder()
+                                                          .withId(FABRIC_INGRESS_SPGW_UPLINK_DROP)
+                                                          .withParameters(Arrays.asList(
+                                                                  new PiActionParam(CTR_ID, UPLINK_COUNTER_CELL_ID)
+                                                          ))
+                                                          .build()).build())
+            .withPriority(DEFAULT_PRIORITY)
+            .build();
+
     public static final FlowRule FABRIC_DOWNLINK_UPF_TERMINATION = DefaultFlowRule.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
             .forTable(FABRIC_INGRESS_SPGW_DOWNLINK_TERMINATIONS)
@@ -252,6 +316,44 @@ public final class TestUpfConstants {
                                     new PiActionParam(QFI, DOWNLINK_QFI)  // 5G case
                             ))
                             .build()).build())
+            .withPriority(DEFAULT_PRIORITY)
+            .build();
+
+    public static final FlowRule FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC = DefaultFlowRule.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
+            .forTable(FABRIC_INGRESS_SPGW_DOWNLINK_TERMINATIONS)
+            .withSelector(DefaultTrafficSelector.builder()
+                      .matchPi(PiCriterion.builder()
+                               // we don't match on slice_id, because we assume distinct UE pools per slice
+                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
+                               .build()).build())
+            .withTreatment(DefaultTrafficTreatment.builder()
+                                   .piTableAction(PiAction.builder()
+                                                          .withId(FABRIC_INGRESS_SPGW_DOWNLINK_FWD_ENCAP_NO_TC)
+                                                          .withParameters(Arrays.asList(
+                                                                  new PiActionParam(CTR_ID, DOWNLINK_COUNTER_CELL_ID),
+                                                                  new PiActionParam(TEID, TEID_VALUE_QOS),
+                                                                  new PiActionParam(QFI, DOWNLINK_QFI)
+                                                          ))
+                                                          .build()).build())
+            .withPriority(DEFAULT_PRIORITY)
+            .build();
+
+    public static final FlowRule FABRIC_DOWNLINK_UPF_TERMINATION_DROP = DefaultFlowRule.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
+            .forTable(FABRIC_INGRESS_SPGW_DOWNLINK_TERMINATIONS)
+            .withSelector(DefaultTrafficSelector.builder()
+                      .matchPi(PiCriterion.builder()
+                               // we don't match on slice_id, because we assume distinct UE pools per slice
+                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
+                               .build()).build())
+            .withTreatment(DefaultTrafficTreatment.builder()
+                                   .piTableAction(PiAction.builder()
+                                                          .withId(FABRIC_INGRESS_SPGW_DOWNLINK_DROP)
+                                                          .withParameters(Arrays.asList(
+                                                                  new PiActionParam(CTR_ID, DOWNLINK_COUNTER_CELL_ID)
+                                                          ))
+                                                          .build()).build())
             .withPriority(DEFAULT_PRIORITY)
             .build();
 


### PR DESCRIPTION
In this case, we rely on default TC behavior programmed via the slicing manager default tc APIs.
Also, adding some test cases for the UpfProgrammable translation layer when we drop in the termination table.