### PR TITLE
Relax buffer pool allocation constraints

### DIFF
--- a/util/gen-qos-config.py
+++ b/util/gen-qos-config.py
@@ -684,7 +684,7 @@ def text_config(yaml_config, type):
     ), f"Too many allocated cells, something is wrong with base_use_limit: {unused_pool_buls}"
     # Account for small rounding errors (since we use floor).
     assert (
-        sum(unused_pool_buls) < max_cells * 0.0001
+        sum(unused_pool_buls) < max_cells * 0.0005
     ), f"Too many unallocated cells, something is wrong with base_use_limit: {unused_pool_buls}"
 
     if type == "stratum":


### PR DESCRIPTION
The previous limit was preventing the generation of real deployment configurations.