### PR TITLE
Fix `vendor_config` generation during linerate tests

### DIFF
--- a/ptf/tests/common/stratum_qos_config.py
+++ b/ptf/tests/common/stratum_qos_config.py
@@ -13,11 +13,11 @@ config_script_path = (
     os.path.dirname(os.path.realpath(__file__)) + "/../../../util/gen-qos-config.py"
 )
 spec = importlib.util.spec_from_file_location(
-    "gen_stratum_qos_config", config_script_path
+    "gen_qos_config", config_script_path
 )
-gen_stratum_qos_config = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(gen_stratum_qos_config)
+gen_qos_config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen_qos_config)
 
 
 def vendor_config(yaml_config):
-    return gen_stratum_qos_config.vendor_config(yaml_config)
+    return gen_qos_config.text_config(yaml_config, type="stratum")


### PR DESCRIPTION
Fixes an issue introduced by #460 that was causing some linerate tests to fail.

```
======================================================================
ERROR [0.365s]: qos_tests.MinFlowrateWithSoftwareLatencyMeasurement
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/fabric-tna/ptf/tests/common/base_test.py", line 1261, in handle
    return f(*args, **kwargs)
  File "/fabric-tna/ptf/tests/linerate/qos_tests.py", line 353, in runTest
    self.push_chassis_config()
  File "/fabric-tna/ptf/tests/linerate/qos_tests.py", line 67, in push_chassis_config
    "\n" + vendor_config(yaml.safe_load(file)), encoding="utf8"
  File "/fabric-tna/ptf/tests/common/stratum_qos_config.py", line 23, in vendor_config
    return gen_stratum_qos_config.vendor_config(yaml_config)
TypeError: vendor_config() missing 1 required positional argument: 'queue_blobs'

----------------------------------------------------------------------
```