### PR TITLE
Temporarily disable canon responses in Stratum

### DIFF
--- a/ptf/run/tm/stratum_entrypoint.sh
+++ b/ptf/run/tm/stratum_entrypoint.sh
@@ -35,4 +35,5 @@ ${stratumBin} \
     -persistent_config_dir=/tmp \
     -write_req_log_file=./p4rt-write-reqs.log \
     -enable_onlp=false \
+    -enable_bfrt_legacy_bytestring_responses=true \
     > ./stratum_bf.log 2>&1

--- a/ptf/run/tm/stratum_entrypoint.sh
+++ b/ptf/run/tm/stratum_entrypoint.sh
@@ -35,5 +35,5 @@ ${stratumBin} \
     -persistent_config_dir=/tmp \
     -write_req_log_file=./p4rt-write-reqs.log \
     -enable_onlp=false \
-    -enable_bfrt_legacy_bytestring_responses=true \
+    -incompatible_enable_bfrt_legacy_bytestring_responses=true \
     > ./stratum_bf.log 2>&1


### PR DESCRIPTION
PTF tests in PR verification jobs are currently broken because of https://github.com/stratum/stratum/pull/918

From: https://jenkins.onosproject.org/job/pr-verify-fabric-tna/310/display/redirect
```
======================================================================
ERROR: test.FabricPacketInPostIngressTest
----------------------------------------------------------------------
Traceback (most recent call last):
 File "../../tests/unary/test.py", line 1157, in runTest
   self.doRunTest(action, post_ingress)
 File "/fabric-tna/ptf/tests/common/base_test.py", line 1287, in handle
   return f(*args, **kwargs)
 File "/fabric-tna/ptf/tests/common/base_test.py", line 1262, in handle
   return f(*args, **kwargs)
 File "../../tests/unary/test.py", line 1150, in doRunTest
   self.verify_packet_in(pkt, self.port1)
 File "/fabric-tna/ptf/tests/common/base_test.py", line 387, in verify_packet_in
   rx_inport = struct.unpack("!h", rx_in_port_)[0]
struct.error: unpack requires a buffer of 2 bytes
```

We are in the process of supporting canonicalization everywhere, we will re-enable canon responses soon.