### PR TITLE
Hardcode BMv2 CPU port in constants

### DIFF
--- a/p4src/v1model/build.sh
+++ b/p4src/v1model/build.sh
@@ -5,8 +5,6 @@
 
 set -e
 
-BMV2_CPU_PORT=255
-
 BMV2_PP_FLAGS=""
 
 PROFILE=$1
@@ -47,9 +45,5 @@ pltf="bmv2"
 # Copy only the relevant files to the pipeconf resources.
 mkdir -p "${DEST_DIR}/${pltf}"
 cp "${output_dir}/p4info.txt" "${DEST_DIR}/${pltf}"
-echo "${BMV2_CPU_PORT}" > "${DEST_DIR}/${pltf}/cpu_port.txt"
 cp "${output_dir}/bmv2.json" "${DEST_DIR}/${pltf}/"
 echo
-
-# CPU port.
-echo ${BMV2_CPU_PORT} > ${P4C_OUT}/cpu_port.txt

--- a/src/main/java/org/stratumproject/fabric/tna/Constants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/Constants.java
@@ -84,6 +84,7 @@ public final class Constants {
 
     public static final long PORT_UNSPECIFIED = 0;
     public static final long PORT_CPU = 0xFFFFFFFDL;
+    public static final long PORT_CPU_BMV2 = 255;
 
     // hide default constructor
     private Constants() {

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricCapabilities.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricCapabilities.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.stratumproject.fabric.tna.Constants.BMV2_COLOR_RED;
+import static org.stratumproject.fabric.tna.Constants.PORT_CPU_BMV2;
 import static org.stratumproject.fabric.tna.Constants.TNA;
 import static org.stratumproject.fabric.tna.Constants.V1MODEL;
 import static org.stratumproject.fabric.tna.Constants.PORT_CPU;
@@ -75,7 +76,7 @@ public class FabricCapabilities {
     }
 
     public Optional<Long> cpuPort() {
-        return Optional.of(PORT_CPU);
+        return isArchTna() ? Optional.of(PORT_CPU) : Optional.of(PORT_CPU_BMV2);
     }
 
     /**


### PR DESCRIPTION
Since we don't support P4Runtime translation in bmv2, we can't use the same CPU port in Tofino and bmv2 because it won't fit in the 9 bits used for `PortId_t` in bmv2.