### PR TITLE
Fix UPF counter idx 0 incremented when no sessions hit

### DIFF
--- a/p4src/tna/include/control/upf.p4
+++ b/p4src/tna/include/control/upf.p4
@@ -171,8 +171,9 @@ control UpfIngress(
         ue_session_id = fabric_md.routing_ipv4_dst;
         session_meter_idx_internal = session_meter_idx;
         fabric_md.bridged.upf.tun_peer_id = tun_peer_id;
-        // When sending to dbuf, even if we don't drop traffic, we want to skip
-        // the egress UPF counter.
+        // Sending to dbuf means buffering, while the egress counter is used only
+        // to keep track of packets effectively sent to UEs. We will update it
+        // when draining from dbuf.
         fabric_md.bridged.upf.skip_egress_upf_ctr = true;
     }
 
@@ -452,9 +453,8 @@ control UpfIngress(
                     downlink_terminations.apply();
                 }
             } else {
-                // If we haven't matched in the session table, but for any reasons
-                // we matched on the interfaces table, we should skip egress UPF
-                // counter.
+                // If here it means we haven't set a counter index and we may have
+                // not dropped the packet.
                 fabric_md.bridged.upf.skip_egress_upf_ctr = true;
             }
             app_color = (MeterColor_t) app_meter.execute(app_meter_idx_internal);

--- a/p4src/tna/include/control/upf.p4
+++ b/p4src/tna/include/control/upf.p4
@@ -477,11 +477,6 @@ control UpfIngress(
             // Nothing to be done immediately for forwarding or encapsulation.
             // Forwarding is done by other parts of the ingress, and
             // encapsulation is done in the egress
-            if (ig_dprsr_md.drop_ctl == 1) {
-                // If, for any reasons, we choose to drop, we should skip
-                // the egress UPF counters.
-                fabric_md.bridged.upf.skip_egress_upf_ctr = true;
-            }
         }
     }
 }

--- a/p4src/tna/include/control/upf.p4
+++ b/p4src/tna/include/control/upf.p4
@@ -163,7 +163,6 @@ control UpfIngress(
         ue_session_id = fabric_md.routing_ipv4_dst;
         session_meter_idx_internal = session_meter_idx;
         fabric_md.bridged.upf.tun_peer_id = tun_peer_id;
-        fabric_md.bridged.upf.skip_egress_upf_ctr = false;
     }
 
     action set_downlink_session_buf(tun_peer_id_t tun_peer_id, session_meter_idx_t session_meter_idx) {
@@ -172,6 +171,8 @@ control UpfIngress(
         ue_session_id = fabric_md.routing_ipv4_dst;
         session_meter_idx_internal = session_meter_idx;
         fabric_md.bridged.upf.tun_peer_id = tun_peer_id;
+        // When sending to dbuf, even if we don't drop traffic, we want to skip
+        // the egress UPF counter.
         fabric_md.bridged.upf.skip_egress_upf_ctr = true;
     }
 
@@ -450,6 +451,11 @@ control UpfIngress(
                 } else {
                     downlink_terminations.apply();
                 }
+            } else {
+                // If we haven't matched in the session table, but for any reasons
+                // we matched on the interfaces table, we should skip egress UPF
+                // counter.
+                fabric_md.bridged.upf.skip_egress_upf_ctr = true;
             }
             app_color = (MeterColor_t) app_meter.execute(app_meter_idx_internal);
             // Color-aware meter, if no app_meter, then app_color is GREEN and
@@ -471,6 +477,11 @@ control UpfIngress(
             // Nothing to be done immediately for forwarding or encapsulation.
             // Forwarding is done by other parts of the ingress, and
             // encapsulation is done in the egress
+            if (ig_dprsr_md.drop_ctl == 1) {
+                // If, for any reasons, we choose to drop, we should skip
+                // the egress UPF counters.
+                fabric_md.bridged.upf.skip_egress_upf_ctr = true;
+            }
         }
     }
 }

--- a/p4src/v1model/include/control/upf.p4
+++ b/p4src/v1model/include/control/upf.p4
@@ -169,8 +169,9 @@ control UpfIngress(
         ue_session_id = fabric_md.routing_ipv4_dst;
         session_meter_idx_internal = session_meter_idx;
         fabric_md.bridged.upf.tun_peer_id = tun_peer_id;
-        // When sending to dbuf, even if we don't drop traffic, we want to skip
-        // the egress UPF counter.
+        // Sending to dbuf means buffering, while the egress counter is used only
+        // to keep track of packets effectively sent to UEs. We will update it
+        // when draining from dbuf.
         fabric_md.bridged.upf.skip_egress_upf_ctr = true;
     }
 
@@ -454,9 +455,8 @@ control UpfIngress(
                     downlink_terminations.apply();
                 }
             } else {
-                // If we haven't matched in the session table, but for any reasons
-                // we matched on the interfaces table, we should skip egress UPF
-                // counter.
+                // If here it means we haven't set a counter index and we may have
+                // not dropped the packet.
                 fabric_md.bridged.upf.skip_egress_upf_ctr = true;
             }
             app_meter.execute_meter((bit<32>) app_meter_idx_internal, fabric_md.upf_meter_color);

--- a/p4src/v1model/include/control/upf.p4
+++ b/p4src/v1model/include/control/upf.p4
@@ -480,11 +480,6 @@ control UpfIngress(
             // Nothing to be done immediately for forwarding or encapsulation.
             // Forwarding is done by other parts of the ingress, and
             // encapsulation is done in the egress
-            if (drop_ctl == 1) {
-                // If, for any reasons, we choose to drop, we should skip
-                // the egress UPF counters.
-                fabric_md.bridged.upf.skip_egress_upf_ctr = true;
-            }
         }
     }
 }

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -2578,7 +2578,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             prefix_len=32,
             iface_type=UPF_IFACE_FROM_DBUF,
             gtpu_valid=True,
-            slice_id=slice_id
+            slice_id=slice_id,
         )
 
     def add_dbuf_device(

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -300,6 +300,7 @@ NO_APP_ID = 0
 DEFAULT_QFI = 1
 DEFAULT_SESSION_METER_IDX = 0
 DEFAULT_APP_METER_IDX = 0
+DEFAULT_UPF_COUNTER_IDX = 0
 TC_WIDTH = 2  # bits
 
 # High-level parameter specification options for get_test_args function
@@ -2571,6 +2572,15 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             slice_id=slice_id,
         )
 
+    def add_dbuf_iface(self, drain_dst_addr, slice_id=DEFAULT_SLICE_ID):
+        self._add_upf_iface(
+            iface_addr=drain_dst_addr,
+            prefix_len=32,
+            iface_type=UPF_IFACE_FROM_DBUF,
+            gtpu_valid=True,
+            slice_id=slice_id
+        )
+
     def add_dbuf_device(
         self,
         dbuf_addr=DBUF_IPV4,
@@ -2579,12 +2589,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
     ):
 
         # Switch interface for traffic to/from dbuf device
-        self._add_upf_iface(
-            iface_addr=drain_dst_addr,
-            prefix_len=32,
-            iface_type=UPF_IFACE_FROM_DBUF,
-            gtpu_valid=True,
-        )
+        self.add_dbuf_iface(drain_dst_addr=drain_dst_addr)
 
         # Configure DBUF as GTP tunnel peer
         self.add_gtp_tunnel_peer(

--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -1265,7 +1265,7 @@ class FabricGtpUnicastEcmpBasedOnTeid(FabricTest):
             self.doRunTest(pkt_type)
 
 @group("upf")
-class FabricUpfCounterUntouchedTest(UpfSimpleTest):
+class FabricUpfCounterBypassTest(UpfSimpleTest):
     """
     This test case verifies that if we don't match on any UPF table, even if packets
     are allowed into the UPF pipeline, egress and ingress UPF counters are not

--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -11,9 +11,9 @@ from base_test import PORT_SIZE_BYTES, autocleanup, is_v1model, tvsetup
 from fabric_test import *  # noqa
 from p4.config.v1 import p4info_pb2
 from ptf.testutils import group
+from scapy.contrib.gtp import GTP_U_Header
 from scapy.layers.inet import IP
 from scapy.layers.ppp import PPPoED
-from scapy.contrib.gtp import GTP_U_Header
 
 
 class FabricBridgingTest(BridgingTest):
@@ -1264,6 +1264,7 @@ class FabricGtpUnicastEcmpBasedOnTeid(FabricTest):
         for pkt_type in BASE_PKT_TYPES:
             self.doRunTest(pkt_type)
 
+
 @group("upf")
 class FabricUpfCounterBypassTest(UpfSimpleTest):
     """
@@ -1274,14 +1275,7 @@ class FabricUpfCounterBypassTest(UpfSimpleTest):
 
     @tvsetup
     @autocleanup
-    def doRunTest(
-            self,
-            pkt,
-            in_port,
-            out_port,
-            exp_pkt,
-            upf_iface
-    ):
+    def doRunTest(self, pkt, in_port, out_port, exp_pkt, upf_iface):
         self.setup_port(in_port, DEFAULT_VLAN, PORT_TYPE_EDGE)
         self.setup_port(out_port, DEFAULT_VLAN, PORT_TYPE_EDGE)
         # Allow packets into the UPF pipeline as if it comes from different interfaces
@@ -1312,15 +1306,10 @@ class FabricUpfCounterBypassTest(UpfSimpleTest):
                     eth_src=HOST1_MAC,
                     eth_dst=SWITCH_MAC,
                     ip_src=HOST1_IPV4,
-                    ip_dst=HOST2_IPV4
+                    ip_dst=HOST2_IPV4,
                 )
-                self.doRunTest(
-                    pkt,
-                    self.port1,
-                    self.port2,
-                    pkt,
-                    upf_iface
-                )
+                self.doRunTest(pkt, self.port1, self.port2, pkt, upf_iface)
+
 
 @group("upf")
 class FabricUpfDownlinkEcmpTest(UpfSimpleTest):


### PR DESCRIPTION
We noticed that the egress UPF counter at index 0 was incremented even if had no traffic for the flow using that UPF counter index.
This happens because traffic can potentially match on the `interfaces` table but miss the sessions table without causing a drop of the packet which would skip the egress UPF counter. This can for example happen if a forwarding decision is taken by ACL.
For this reason, we ensure to skip the egress UPF counter if we have a miss in the sessions table (`sess_hit` is false).
