### PR TITLE
Fix meter linerate tests

### DIFF
--- a/ptf/tests/common/trex_utils.py
+++ b/ptf/tests/common/trex_utils.py
@@ -105,53 +105,34 @@ def list_port_status(port_status: dict) -> None:
         print("States from port {}: \n{}".format(port, readable_stats))
 
 
-def monitor_port_stats(c: STLClient) -> dict:
+def monitor_port_stats(c: STLClient, ports: []) -> dict:
     """
     List some port stats continuously while traffic is active 
 
     :parameters:
     c: STLClient
         TRex stateless client to continuously grab statistics from
+    ports: []
+        List of ports to monitor
     """
-    ports = [0, 1, 2, 3]
-
     results = {
-        "duration": [],
-        0: {"rx_bps": [], "tx_bps": [], "rx_pps": [], "tx_pps": []},
-        1: {"rx_bps": [], "tx_bps": [], "rx_pps": [], "tx_pps": []},
-        2: {"rx_bps": [], "tx_bps": [], "rx_pps": [], "tx_pps": []},
-        3: {"rx_bps": [], "tx_bps": [], "rx_pps": [], "tx_pps": []},
+        port_id: {"rx_bps": [], "tx_bps": [], "rx_pps": [], "tx_pps": []}
+        for port_id in ports
     }
+    results["duration"] = []
+
+    if not ports:
+        return results
 
     prev = {
-        0: {
+        port_id: {
             "opackets": 0,
             "ipackets": 0,
             "obytes": 0,
             "ibytes": 0,
             "time": time.time(),
-        },
-        1: {
-            "opackets": 0,
-            "ipackets": 0,
-            "obytes": 0,
-            "ibytes": 0,
-            "time": time.time(),
-        },
-        2: {
-            "opackets": 0,
-            "ipackets": 0,
-            "obytes": 0,
-            "ibytes": 0,
-            "time": time.time(),
-        },
-        3: {
-            "opackets": 0,
-            "ipackets": 0,
-            "obytes": 0,
-            "ibytes": 0,
-            "time": time.time(),
-        },
+        }
+        for port_id in ports
     }
 
     s_time = time.time()


### PR DESCRIPTION
On a run of meter linerate tests, we noticed that removing the first sample from live statistics is not enough to get the TX/RX rate at the regime.
For this reason, we remove the first and last 2 samples if we have enough, otherwise we consider all samples in the live stats. Since all linerate meter tests last 10 seconds, and samples are captured every 1 second, we should have enough sample to remove first and last 2.
Also, extending `monitor_port_stats` to pass also the list of ports.