### PR TITLE
[SDFAB-1097] Do not generate INT report for pruned packets

### DIFF
--- a/p4src/tna/include/control/next.p4
+++ b/p4src/tna/include/control/next.p4
@@ -278,7 +278,9 @@ control EgressNextControl (inout egress_headers_t hdr,
     apply {
         if (fabric_md.bridged.base.is_multicast
              && fabric_md.bridged.base.ig_port == eg_intr_md.egress_port) {
+#ifdef WITH_INT
             fabric_md.bridged.int_bmd.report_type = INT_REPORT_TYPE_NO_REPORT;
+#endif // WITH_INT
             eg_dprsr_md.drop_ctl = 1;
         }
 

--- a/p4src/tna/include/control/next.p4
+++ b/p4src/tna/include/control/next.p4
@@ -278,6 +278,7 @@ control EgressNextControl (inout egress_headers_t hdr,
     apply {
         if (fabric_md.bridged.base.is_multicast
              && fabric_md.bridged.base.ig_port == eg_intr_md.egress_port) {
+            fabric_md.bridged.int_bmd.report_type = INT_REPORT_TYPE_NO_REPORT;
             eg_dprsr_md.drop_ctl = 1;
         }
 

--- a/p4src/v1model/include/control/int.p4
+++ b/p4src/v1model/include/control/int.p4
@@ -297,7 +297,7 @@ control IntEgress (inout v1model_header_t          hdr_v1model,
         fabric_md.int_report_md.mirror_type = FabricMirrorType_t.INT_REPORT;
         fabric_md.int_report_md.report_type = fabric_md.bridged.int_bmd.report_type;
         fabric_md.int_report_md.ig_port = fabric_md.bridged.base.ig_port;
-        fabric_md.int_report_md.eg_port = (PortId_t)fabric_v1model.recirc_preserved_egress_port;
+        fabric_md.int_report_md.eg_port = (PortId_t)standard_md.egress_port;
         fabric_md.int_report_md.queue_id = egress_qid;
         fabric_md.int_report_md.queue_occupancy = standard_md.deq_qdepth;
         fabric_md.int_report_md.ig_tstamp = fabric_md.bridged.base.ig_tstamp[31:0];

--- a/p4src/v1model/include/control/next.p4
+++ b/p4src/v1model/include/control/next.p4
@@ -279,7 +279,9 @@ control EgressNextControl (inout ingress_headers_t        hdr,
     apply {
         if (fabric_md.bridged.base.is_multicast
              && fabric_md.bridged.base.ig_port == standard_md.egress_port) {
+#ifdef WITH_INT
             fabric_md.bridged.int_bmd.report_type = INT_REPORT_TYPE_NO_REPORT;
+#endif // WITH_INT
             drop_ctl = 1;
         }
 

--- a/p4src/v1model/include/control/next.p4
+++ b/p4src/v1model/include/control/next.p4
@@ -279,6 +279,7 @@ control EgressNextControl (inout ingress_headers_t        hdr,
     apply {
         if (fabric_md.bridged.base.is_multicast
              && fabric_md.bridged.base.ig_port == standard_md.egress_port) {
+            fabric_md.bridged.int_bmd.report_type = INT_REPORT_TYPE_NO_REPORT;
             drop_ctl = 1;
         }
 

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -893,12 +893,9 @@ class FabricTest(P4RuntimeTest):
         # Initialize the SDN-to-SDK port mapping, this port mapping is used for tests
         # which doesn't support port translation.
         # For example, port numbers in INT reports are not translated to singleton port.
-        if self.generate_tv:
-            # Build a fake SDN to SDK port mapping for testvector
+        if self.generate_tv or is_v1model():
+            # Build a fake SDN to SDK port mapping for testvector and bmv2
             self.sdn_to_sdk_port = dict([(_, _) for _ in range(1, 5)])
-        elif is_v1model():
-            # SDN and SDK port numbers are the same in bmv2
-            self.sdn_to_sdk_port = dict([(_, _) for _ in range(0, 4)])
             self.sdn_to_sdk_port[255] = 255  # CPU port for bmv2
         else:
             # For Tofino Model and real hardware, use gNMI to get the SDN port to SDK

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -2097,7 +2097,7 @@ class IPv4UnicastTest(FabricTest):
 
 
 class IPv4MulticastTest(FabricTest):
-    def runIPv4MulticastTest(self, pkt, in_port, out_ports, in_vlan, out_vlan):
+    def runIPv4MulticastTest(self, pkt, in_port, out_ports, in_vlan, out_vlan, with_another_pkt_later=False):
         if Dot1Q in pkt:
             print("runIPv4MulticastTest() expects untagged packets")
             return
@@ -2113,6 +2113,8 @@ class IPv4MulticastTest(FabricTest):
         # Set port VLAN
         self.setup_port(in_port, internal_in_vlan, PORT_TYPE_EDGE, in_vlan is not None)
         for out_port in out_ports:
+            if out_port == in_port:
+                continue
             self.setup_port(
                 out_port, internal_out_vlan, PORT_TYPE_INFRA, out_vlan is not None
             )
@@ -2149,8 +2151,12 @@ class IPv4MulticastTest(FabricTest):
         # Send packets and verify
         self.send_packet(in_port, pkt)
         for out_port in out_ports:
+            if out_port == in_port:
+                # Packet will be dropped by egress pipeline.
+                continue
             self.verify_packet(expect_pkt, out_port)
-        self.verify_no_other_packets()
+        if not with_another_pkt_later:
+            self.verify_no_other_packets()
 
 
 class DoubleVlanTerminationTest(FabricTest):

--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -2330,6 +2330,42 @@ class FabricIntQueueReportQuotaTest(IntTest):
         )
 
 
+@group("int")
+class FabricIntMulticastReportTest(IntTest, IPv4MulticastTest):
+
+    @tvsetup
+    @autocleanup
+    def doRunTest(self):
+        pkt = testutils.simple_udp_packet(
+            eth_dst="01:00:5e:00:00:01", ip_dst="224.0.0.1"
+        )
+        in_port = self.port1
+        out_ports = [self.port1, self.port2, self.port4] # port3 for INT collector.
+        self.set_up_int_flows(False, pkt, False)
+        self.runIPv4MulticastTest(pkt, in_port, out_ports, None, None, True)
+
+        exp_pkt = pkt_decrement_ttl(pkt)
+        for out_port in out_ports:
+            if out_port == in_port:
+                continue
+            flow_report = self.build_int_local_report(
+                SWITCH_MAC,
+                INT_COLLECTOR_MAC,
+                SWITCH_IPV4,
+                INT_COLLECTOR_IPV4,
+                self.sdn_to_sdk_port[in_port],
+                self.sdn_to_sdk_port[out_port],
+                SWITCH_ID,
+                exp_pkt,
+                False,
+                False,
+            )
+            self.verify_packet(flow_report, self.port3)
+        self.verify_no_other_packets()
+
+    def runTest(self):
+        self.doRunTest()
+
 @group("bng")
 class FabricPppoeUpstreamTest(PppoeTest):
     @tvsetup


### PR DESCRIPTION
When sending multicast/broadcast traffic, we always drop packets if the egress port is equal to the ingress port.
This caused the INT pipeline to generate unnecessary INT drop reports.
To avoid this, we can set the report type to NO_REPORT for this case.