### PR TITLE
[SDFAB-1104] Add slice meter support for UPF traffic

### DIFF
--- a/p4src/tna/include/control/upf.p4
+++ b/p4src/tna/include/control/upf.p4
@@ -269,12 +269,6 @@ control UpfIngress(
         fabric_md.tc_unknown = false;
     }
 
-    action app_fwd_no_tc(upf_ctr_idx_t ctr_id, app_meter_idx_t app_meter_idx) {
-        _term_hit(ctr_id);
-        fabric_md.tc_unknown = true;
-        app_meter_idx_internal = app_meter_idx;
-    }
-
     action downlink_fwd_encap(upf_ctr_idx_t ctr_id,
                               tc_t         tc,
                               teid_t       teid,
@@ -282,15 +276,6 @@ control UpfIngress(
                               bit<6>       qfi,
                               app_meter_idx_t app_meter_idx) {
         app_fwd(ctr_id, tc, app_meter_idx);
-        _set_field_encap(teid, qfi);
-    }
-
-    action downlink_fwd_encap_no_tc(upf_ctr_idx_t ctr_id,
-                                    teid_t       teid,
-                                    // QFI should always equal 0 for 4G flows
-                                    bit<6>       qfi,
-                                    app_meter_idx_t app_meter_idx) {
-        app_fwd_no_tc(ctr_id, app_meter_idx);
         _set_field_encap(teid, qfi);
     }
 
@@ -302,7 +287,6 @@ control UpfIngress(
 
         actions = {
             app_fwd;
-            app_fwd_no_tc;
             uplink_drop;
             @defaultonly uplink_drop_miss;
         }
@@ -317,7 +301,6 @@ control UpfIngress(
         }
         actions = {
             downlink_fwd_encap;
-            downlink_fwd_encap_no_tc;
             downlink_drop;
             @defaultonly downlink_drop_miss;
         }

--- a/p4src/v1model/include/control/upf.p4
+++ b/p4src/v1model/include/control/upf.p4
@@ -267,12 +267,6 @@ control UpfIngress(
         fabric_md.tc_unknown = false;
     }
 
-    action app_fwd_no_tc(upf_ctr_idx_t ctr_id, app_meter_idx_t app_meter_idx) {
-        _term_hit(ctr_id);
-        fabric_md.tc_unknown = true;
-        app_meter_idx_internal = app_meter_idx;
-    }
-
     action downlink_fwd_encap(upf_ctr_idx_t ctr_id,
                               tc_t         tc,
                               teid_t       teid,
@@ -280,15 +274,6 @@ control UpfIngress(
                               bit<6>       qfi,
                               app_meter_idx_t app_meter_idx) {
         app_fwd(ctr_id, tc, app_meter_idx);
-        _set_field_encap(teid, qfi);
-    }
-
-    action downlink_fwd_encap_no_tc(upf_ctr_idx_t ctr_id,
-                                    teid_t       teid,
-                                    // QFI should always equal 0 for 4G flows
-                                    bit<6>       qfi,
-                                    app_meter_idx_t app_meter_idx) {
-        app_fwd_no_tc(ctr_id, app_meter_idx);
         _set_field_encap(teid, qfi);
     }
 
@@ -300,7 +285,6 @@ control UpfIngress(
 
         actions = {
             app_fwd;
-            app_fwd_no_tc;
             uplink_drop;
             @defaultonly uplink_drop_miss;
         }
@@ -315,7 +299,6 @@ control UpfIngress(
         }
         actions = {
             downlink_fwd_encap;
-            downlink_fwd_encap_no_tc;
             downlink_drop;
             @defaultonly downlink_drop_miss;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@ SPDX-License-Identifier: Apache-2.0
             <id>snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
                 <updatePolicy>always</updatePolicy>
                 <checksumPolicy>fail</checksumPolicy>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@ SPDX-License-Identifier: Apache-2.0
             <id>snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
                 <checksumPolicy>fail</checksumPolicy>
             </snapshots>

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -2717,12 +2717,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             ("ctr_id", stringify(ctr_id, 2)),
         ]
         if not drop:
+            action_name = "FabricIngress.upf.app_fwd"
             action_params.append(("app_meter_idx", stringify(app_meter_idx, 2)))
-            if tc is not None:
-                action_name = "FabricIngress.upf.app_fwd"
-                action_params.append(("tc", stringify(tc, 1)))
-            else:
-                action_name = "FabricIngress.upf.app_fwd_no_tc"
+            action_params.append(("tc", stringify(tc, 1)))
         else:
             action_name = "FabricIngress.upf.uplink_drop"
         self.push_update_add_entry_to_action(
@@ -2806,15 +2803,14 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         req = self.get_new_write_request()
         action_params = [("ctr_id", stringify(ctr_id, 2))]
         if not drop:
-            action_params = [("ctr_id", stringify(ctr_id, 2))]
-            action_params.append(("qfi", stringify(qfi, 1)))
-            action_params.append(("teid", stringify(teid, 4)))
-            action_params.append(("app_meter_idx", stringify(app_meter_idx, 2)))
-            if tc is not None:
-                action_name = "FabricIngress.upf.downlink_fwd_encap"
-                action_params.append(("tc", stringify(tc, 1)))
-            else:
-                action_name = "FabricIngress.upf.downlink_fwd_encap_no_tc"
+            action_name = "FabricIngress.upf.downlink_fwd_encap"
+            action_params = [
+                ("ctr_id", stringify(ctr_id, 2)),
+                ("qfi", stringify(qfi, 1)),
+                ("teid", stringify(teid, 4)),
+                ("app_meter_idx", stringify(app_meter_idx, 2)),
+                ("tc", stringify(tc, 1))
+            ]
         else:
             action_name = "FabricIngress.upf.downlink_drop"
         self.push_update_add_entry_to_action(
@@ -2867,7 +2863,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         teid,
         ctr_id,
         slice_id=DEFAULT_SLICE_ID,
-        tc=None,
+        tc=DEFAULT_TC,
         app_id=NO_APP_ID,
         app_meter_idx=DEFAULT_APP_METER_IDX,
         session_meter_idx=DEFAULT_SESSION_METER_IDX,
@@ -2890,7 +2886,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         ue_addr,
         ctr_id,
         slice_id=DEFAULT_SLICE_ID,
-        tc=None,
+        tc=DEFAULT_TC,
         qfi=DEFAULT_QFI,
         tunnel_peer_id=S1U_ENB_TUNNEL_PEER_ID,
         app_id=NO_APP_ID,
@@ -2952,7 +2948,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         with_psc,
         is_next_hop_spine,
         slice_id=DEFAULT_SLICE_ID,
-        tc=None,
+        tc=DEFAULT_TC,
         dscp_rewrite=False,
         verify_counters=True,
         eg_port=None,
@@ -2984,11 +2980,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         if tagged2:
             exp_pkt = pkt_add_vlan(exp_pkt, VLAN_ID_2)
         if dscp_rewrite:
-            if tc is None:
-                # Use default TC
-                exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=DEFAULT_TC)
-            else:
-                exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=tc)
+            exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=tc)
 
         app_id = NO_APP_ID
         if app_filtering:
@@ -3015,7 +3007,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         if meter_drop:
             self.enable_policing(
                 slice_id,
-                DEFAULT_TC if tc is None else tc,
+                tc,
                 V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
             )
         app_meter_idx = DEFAULT_APP_METER_IDX
@@ -3244,7 +3236,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         with_psc,
         is_next_hop_spine,
         slice_id=DEFAULT_SLICE_ID,
-        tc=None,
+        tc=DEFAULT_TC,
         dscp_rewrite=False,
         verify_counters=True,
         eg_port=None,
@@ -3272,10 +3264,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             exp_pkt = pkt_add_vlan(exp_pkt, VLAN_ID_2)
         if dscp_rewrite:
             # Modify outer IPV4
-            if tc is None:
-                exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=DEFAULT_TC)
-            else:
-                exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=tc)
+            exp_pkt = pkt_set_dscp(exp_pkt, slice_id=slice_id, tc=tc)
 
         app_id = NO_APP_ID
         if app_filtering:
@@ -3302,7 +3291,7 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         if meter_drop:
             self.enable_policing(
                 slice_id,
-                DEFAULT_TC if tc is None else tc,
+                tc,
                 V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
             )
         app_meter_idx = DEFAULT_APP_METER_IDX

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/FabricUtils.java
@@ -3,6 +3,7 @@
 
 package org.stratumproject.fabric.tna.behaviour;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.onlab.util.KryoNamespace;
 import org.onosproject.net.PortNumber;
 import org.onosproject.net.flow.TrafficSelector;
@@ -137,6 +138,17 @@ public final class FabricUtils {
         checkArgument(sliceId >= 0 && sliceId <= MAX_SLICE_ID, "Invalid sliceId");
         checkArgument(tc >= 0 && tc <= MAX_TC, "Invalid tc");
         return (sliceId << TC_BITWIDTH) + tc;
+    }
+
+    /**
+     * Return a pair containing slice ID and Traffic Class extracted from the given
+     * slice and TC concatenation.
+     *
+     * @param sliceTc slice ID and TC concatenated
+     * @return Pair containing separate slice ID and TC
+     */
+    public static ImmutablePair<Integer, Integer> sliceTcSplit(int sliceTc) {
+        return ImmutablePair.of((sliceTc & 0b111100) >> 2, sliceTc & 0b11);
     }
 
     /**

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/P4InfoConstants.java
@@ -358,16 +358,12 @@ public final class P4InfoConstants {
             PiActionId.of("FabricIngress.stats.count");
     public static final PiActionId FABRIC_INGRESS_UPF_APP_FWD =
             PiActionId.of("FabricIngress.upf.app_fwd");
-    public static final PiActionId FABRIC_INGRESS_UPF_APP_FWD_NO_TC =
-            PiActionId.of("FabricIngress.upf.app_fwd_no_tc");
     public static final PiActionId FABRIC_INGRESS_UPF_DOWNLINK_DROP =
             PiActionId.of("FabricIngress.upf.downlink_drop");
     public static final PiActionId FABRIC_INGRESS_UPF_DOWNLINK_DROP_MISS =
             PiActionId.of("FabricIngress.upf.downlink_drop_miss");
     public static final PiActionId FABRIC_INGRESS_UPF_DOWNLINK_FWD_ENCAP =
             PiActionId.of("FabricIngress.upf.downlink_fwd_encap");
-    public static final PiActionId FABRIC_INGRESS_UPF_DOWNLINK_FWD_ENCAP_NO_TC =
-            PiActionId.of("FabricIngress.upf.downlink_fwd_encap_no_tc");
     public static final PiActionId FABRIC_INGRESS_UPF_IFACE_ACCESS =
             PiActionId.of("FabricIngress.upf.iface_access");
     public static final PiActionId FABRIC_INGRESS_UPF_IFACE_CORE =

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stratumproject.fabric.tna.Constants;
 import org.stratumproject.fabric.tna.behaviour.FabricCapabilities;
+import org.stratumproject.fabric.tna.behaviour.FabricUtils;
 import org.stratumproject.fabric.tna.slicing.api.SliceId;
 import org.stratumproject.fabric.tna.slicing.api.SlicingService;
 import org.stratumproject.fabric.tna.slicing.api.TrafficClass;
@@ -731,10 +732,9 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
     private void applyUpfMeter(UpfMeter upfMeter) throws UpfProgrammableException {
         if (upfMeter.type().equals(UpfEntityType.SLICE_METER)) {
             // cell ID for slice meter is concatenation of slice ID and traffic class (sliceId++tc)
-            final int sliceId = (upfMeter.cellId() & 0b111100) >> 2;
-            final int tc = upfMeter.cellId() & 0b11;
-            assertSliceId(sliceId);
-            assertTrafficClass(sliceId, tc);
+            final Pair<Integer, Integer> sliceAndTc = FabricUtils.sliceTcSplit(upfMeter.cellId());
+            assertSliceId(sliceAndTc.getLeft());
+            assertTrafficClass(sliceAndTc.getLeft(), sliceAndTc.getRight());
         }
         MeterRequest meterRequest = upfTranslator.upfMeterToFabricMeter(upfMeter, deviceId, appId);
         if (upfMeter.isReset()) {

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammable.java
@@ -55,6 +55,7 @@ import org.stratumproject.fabric.tna.Constants;
 import org.stratumproject.fabric.tna.behaviour.FabricCapabilities;
 import org.stratumproject.fabric.tna.slicing.api.SliceId;
 import org.stratumproject.fabric.tna.slicing.api.SlicingService;
+import org.stratumproject.fabric.tna.slicing.api.TrafficClass;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -728,6 +729,13 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
     }
 
     private void applyUpfMeter(UpfMeter upfMeter) throws UpfProgrammableException {
+        if (upfMeter.type().equals(UpfEntityType.SLICE_METER)) {
+            // cell ID for slice meter is concatenation of slice ID and traffic class (sliceId++tc)
+            final int sliceId = (upfMeter.cellId() & 0b111100) >> 2;
+            final int tc = upfMeter.cellId() & 0b11;
+            assertSliceId(sliceId);
+            assertTrafficClass(sliceId, tc);
+        }
         MeterRequest meterRequest = upfTranslator.upfMeterToFabricMeter(upfMeter, deviceId, appId);
         if (upfMeter.isReset()) {
             log.info("Resetting meter {}", meterRequest);
@@ -1012,6 +1020,16 @@ public class FabricUpfProgrammable extends AbstractP4RuntimeHandlerBehaviour
             throw new UpfProgrammableException(format(
                     "Provided slice ID (%d) is not available in slicing service!",
                     sliceId
+            ));
+        }
+    }
+
+    private void assertTrafficClass(int sliceId, int tc) throws UpfProgrammableException {
+        TrafficClass trafficClass = TrafficClass.fromInteger(tc);
+        if (!slicingService.getTrafficClasses(SliceId.of(sliceId)).contains(trafficClass)) {
+            throw new UpfProgrammableException(format(
+                    "Provided traffic class (%s) is not available for provided slice ID (%d) in slicing service!",
+                    trafficClass, sliceId
             ));
         }
     }

--- a/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslator.java
+++ b/src/main/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslator.java
@@ -418,10 +418,6 @@ public class FabricUpfTranslator {
         assertMeterId(meter, FABRIC_INGRESS_UPF_SESSION_METER);
         assertMeterBands(meter);
         List<Band> peakBand = getMeterBand(meter, Band.Type.MARK_RED);
-        List<Band> committedBand = getMeterBand(meter, Band.Type.MARK_YELLOW);
-        if (committedBand.get(0).rate() != 0 || committedBand.get(0).burst() != 0) {
-            log.warn("Session meter have unexpected committed band - IGNORING: " + committedBand);
-        }
         return UpfMeter.builder()
                 .setSession()
                 .setCellId((int) ((PiMeterCellId) meter.meterCellId()).index())
@@ -446,10 +442,6 @@ public class FabricUpfTranslator {
         assertMeterId(meter, FABRIC_INGRESS_QOS_SLICE_TC_METER);
         assertMeterBands(meter);
         List<Band> peakBand = getMeterBand(meter, Band.Type.MARK_RED);
-        List<Band> committedBand = getMeterBand(meter, Band.Type.MARK_YELLOW);
-        if (committedBand.get(0).rate() != 0 || committedBand.get(0).burst() != 0) {
-            log.warn("Slice meter have unexpected committed band - IGNORING: " + committedBand);
-        }
         return UpfMeter.builder()
                 .setSlice()
                 .setCellId((int) ((PiMeterCellId) meter.meterCellId()).index())

--- a/src/main/java/org/stratumproject/fabric/tna/slicing/api/TrafficClass.java
+++ b/src/main/java/org/stratumproject/fabric/tna/slicing/api/TrafficClass.java
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.stratumproject.fabric.tna.slicing.api;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.stratumproject.fabric.tna.Constants.MAX_TC;
+
 /**
  * Type of traffic class.
  */
@@ -10,6 +13,8 @@ public enum TrafficClass {
     CONTROL(1),
     REAL_TIME(2),
     ELASTIC(3);
+
+    public static final Integer MAX = MAX_TC;
 
     public final int intValue;
 
@@ -26,5 +31,29 @@ public enum TrafficClass {
      */
     public int toInt() {
         return intValue;
+    }
+
+    /**
+     * Constructs a traffic class instance from the unique integer identifier.
+     *
+     * @param tcId traffic class integer unique identifier
+     * @return TrafficClass instance
+     * @throws IllegalArgumentException if given tc is invalid
+     */
+    public static TrafficClass fromInteger(int tcId) {
+        checkArgument(tcId >= 0 && tcId <= MAX, "Invalid tc %s. Valid range is from %s to %s", tcId, 0, MAX);
+        switch (tcId) {
+            case 0:
+                return BEST_EFFORT;
+            case 1:
+                return CONTROL;
+            case 2:
+                return REAL_TIME;
+            case 3:
+                return ELASTIC;
+            default:
+                // Should never reach this point
+                throw new IllegalArgumentException("Invalid traffic class identifier");
+        }
     }
 }

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricUtilsTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/FabricUtilsTest.java
@@ -3,27 +3,49 @@
 
 package org.stratumproject.fabric.tna.behaviour;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.stratumproject.fabric.tna.behaviour.FabricUtils.sliceTcConcat;
+import static org.stratumproject.fabric.tna.behaviour.FabricUtils.sliceTcSplit;
 
 /**
  * Tests for FabricUtils.
  */
 public class FabricUtilsTest {
 
+    ImmutableMap<Integer, Pair<Integer, Integer>> sliceTcMap =
+            ImmutableMap.<Integer, Pair<Integer, Integer>>builder()
+                    .put(0b000000, ImmutablePair.of(0, 0))
+                    .put(0b000001, ImmutablePair.of(0, 1))
+                    .put(0b000010, ImmutablePair.of(0, 2))
+                    .put(0b000011, ImmutablePair.of(0, 3))
+                    .put(0b101100, ImmutablePair.of(11, 0))
+                    .put(0b111100, ImmutablePair.of(15, 0))
+                    .put(0b111101, ImmutablePair.of(15, 1))
+                    .put(0b111110, ImmutablePair.of(15, 2))
+                    .put(0b111111, ImmutablePair.of(15, 3))
+                    .build();
+
     @Test
     public void testSliceTcConcat() {
-        assertThat(sliceTcConcat(0, 0), equalTo(0b000000));
-        assertThat(sliceTcConcat(0, 1), equalTo(0b000001));
-        assertThat(sliceTcConcat(0, 2), equalTo(0b000010));
-        assertThat(sliceTcConcat(0, 3), equalTo(0b000011));
-        assertThat(sliceTcConcat(11, 0), equalTo(0b101100));
-        assertThat(sliceTcConcat(15, 0), equalTo(0b111100));
-        assertThat(sliceTcConcat(15, 1), equalTo(0b111101));
-        assertThat(sliceTcConcat(15, 2), equalTo(0b111110));
-        assertThat(sliceTcConcat(15, 3), equalTo(0b111111));
+        for (var entry : sliceTcMap.entrySet()) {
+            int sliceTcConcat = entry.getKey();
+            Pair<Integer, Integer> sliceTcSeprated = entry.getValue();
+            assertThat(sliceTcConcat(sliceTcSeprated.getLeft(), sliceTcSeprated.getRight()), equalTo(sliceTcConcat));
+        }
+    }
+
+    @Test
+    public void testSliceTcSplit() {
+        for (var entry : sliceTcMap.entrySet()) {
+            int sliceTcConcat = entry.getKey();
+            Pair<Integer, Integer> sliceTcSeprated = entry.getValue();
+            assertThat(sliceTcSplit(sliceTcConcat), equalTo(sliceTcSeprated));
+        }
     }
 }

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammableTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammableTest.java
@@ -4,7 +4,9 @@ package org.stratumproject.fabric.tna.behaviour.upf;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.onlab.junit.TestUtils;
 import org.onlab.packet.Ip4Prefix;
 import org.onlab.util.HexString;
@@ -44,6 +46,7 @@ import org.stratumproject.fabric.tna.Constants;
 import org.stratumproject.fabric.tna.behaviour.FabricCapabilities;
 import org.stratumproject.fabric.tna.slicing.api.SliceId;
 import org.stratumproject.fabric.tna.slicing.api.SlicingService;
+import org.stratumproject.fabric.tna.slicing.api.TrafficClass;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -124,6 +127,9 @@ public class FabricUpfProgrammableTest {
                                TestUpfConstants.PHYSICAL_MAX_SLICE_METERS)
     );
 
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
     @Before
     public void setUp() throws Exception {
         FabricCapabilities capabilities = createMock(FabricCapabilities.class);
@@ -137,6 +143,8 @@ public class FabricUpfProgrammableTest {
         DeviceService deviceService = createMock(DeviceService.class);
         SlicingService slicingService = createMock(SlicingService.class);
         expect(slicingService.getSlices()).andReturn(Set.of(SliceId.of(SLICE_MOBILE))).anyTimes();
+        expect(slicingService.getTrafficClasses(SliceId.of(SLICE_MOBILE)))
+                .andReturn(Set.of(TrafficClass.ELASTIC)).anyTimes();
         PiTranslationService piTranslationService = createMock(PiTranslationService.class);
         expect(coreService.getAppId(anyString())).andReturn(APP_ID).anyTimes();
         expect(netcfgService.getConfig(TestUpfConstants.DEVICE_ID, BasicDeviceConfig.class))
@@ -267,8 +275,10 @@ public class FabricUpfProgrammableTest {
         assertTrue(upfProgrammable.readAll(UpfEntityType.INTERFACE).isEmpty());
     }
 
-    @Test(expected = UpfProgrammableException.class)
+    @Test
     public void testInvalidSliceIdInterface() throws Exception {
+        exceptionRule.expect(UpfProgrammableException.class);
+        exceptionRule.expectMessage("Provided slice ID (0) is not available in slicing service!");
         assertTrue(upfProgrammable.readAll(UpfEntityType.INTERFACE).isEmpty());
         upfProgrammable.apply(UpfInterface.createUePoolFrom(Ip4Prefix.valueOf("10.0.0.0/24"), 0));
     }
@@ -288,8 +298,10 @@ public class FabricUpfProgrammableTest {
         assertTrue(upfProgrammable.readAll(UpfEntityType.APPLICATION).isEmpty());
     }
 
-    @Test(expected = UpfProgrammableException.class)
+    @Test
     public void testInvalidSliceIdUpfApplication() throws Exception {
+        exceptionRule.expect(UpfProgrammableException.class);
+        exceptionRule.expectMessage("Provided slice ID (0) is not available in slicing service!");
         assertTrue(upfProgrammable.readAll(UpfEntityType.INTERFACE).isEmpty());
         upfProgrammable.apply(TestUpfConstants.APPLICATION_FILTERING_INVALID_SLICE_ID);
     }
@@ -337,6 +349,23 @@ public class FabricUpfProgrammableTest {
         }
         upfProgrammable.apply(TestUpfConstants.SLICE_METER_RESET);
         assertTrue(upfProgrammable.readAll(UpfEntityType.SLICE_METER).isEmpty());
+    }
+
+    @Test
+    public void testInvalidSliceIdSliceMeter() throws Exception {
+        exceptionRule.expect(UpfProgrammableException.class);
+        exceptionRule.expectMessage("Provided slice ID (0) is not available in slicing service!");
+        assertTrue(upfProgrammable.readAll(UpfEntityType.SLICE_METER).isEmpty());
+        upfProgrammable.apply(TestUpfConstants.SLICE_METER_INVALID_SLICE_ID);
+    }
+
+    @Test
+    public void testInvalidTrafficClassSliceMeter() throws Exception {
+        exceptionRule.expect(UpfProgrammableException.class);
+        exceptionRule.expectMessage(
+                "Provided traffic class (BEST_EFFORT) is not available for provided slice ID (10) in slicing service!");
+        assertTrue(upfProgrammable.readAll(UpfEntityType.SLICE_METER).isEmpty());
+        upfProgrammable.apply(TestUpfConstants.SLICE_METER_INVALID_TC);
     }
 
     @Test

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammableTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfProgrammableTest.java
@@ -63,6 +63,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.stratumproject.fabric.tna.Constants.TNA;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_EG_TUNNEL_PEERS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_QOS_SLICE_TC_METER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APPLICATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APP_METER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_SESSIONS;
@@ -118,7 +119,9 @@ public class FabricUpfProgrammableTest {
             new MockMeterModel(FABRIC_INGRESS_UPF_SESSION_METER,
                                  TestUpfConstants.PHYSICAL_SESSION_METER_SIZE),
             new MockMeterModel(FABRIC_INGRESS_UPF_APP_METER,
-                                 TestUpfConstants.PHYSICAL_APP_METER_SIZE)
+                                 TestUpfConstants.PHYSICAL_APP_METER_SIZE),
+            new MockMeterModel(FABRIC_INGRESS_QOS_SLICE_TC_METER,
+                               TestUpfConstants.PHYSICAL_MAX_SLICE_METERS)
     );
 
     @Before
@@ -318,6 +321,22 @@ public class FabricUpfProgrammableTest {
         }
         upfProgrammable.apply(TestUpfConstants.SESSION_METER_RESET);
         assertTrue(upfProgrammable.readAll(UpfEntityType.SESSION_METER).isEmpty());
+    }
+
+    @Test
+    public void testSliceMeter() throws Exception {
+        // Slice Meters
+        assertTrue(upfProgrammable.readAll(UpfEntityType.SLICE_METER).isEmpty());
+        UpfMeter expectedSliceMeter = TestUpfConstants.SLICE_METER;
+        upfProgrammable.apply(expectedSliceMeter);
+        Collection<? extends UpfEntity> installedSliceMeters =
+                upfProgrammable.readAll(UpfEntityType.SLICE_METER);
+        assertThat(installedSliceMeters.size(), equalTo(1));
+        for (var readSliceMeter : installedSliceMeters) {
+            assertThat(readSliceMeter, equalTo(expectedSliceMeter));
+        }
+        upfProgrammable.apply(TestUpfConstants.SLICE_METER_RESET);
+        assertTrue(upfProgrammable.readAll(UpfEntityType.SLICE_METER).isEmpty());
     }
 
     @Test

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslatorTest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/FabricUpfTranslatorTest.java
@@ -99,22 +99,6 @@ public class FabricUpfTranslatorTest {
     }
 
     @Test
-    public void fabricEntryToUplinkUpfTerminationNoTcTest() {
-        UpfTerminationUplink translatedUpfTerminationRule;
-        UpfTerminationUplink expected = TestUpfConstants.UPLINK_UPF_TERMINATION_NO_TC;
-        try {
-            translatedUpfTerminationRule = upfTranslator
-                    .fabricEntryToUpfTerminationUplink(TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_NO_TC);
-        } catch (UpfProgrammableException e) {
-            assertThat("Fabric uplink UPF termination rule should correctly " +
-                               "translate to abstract UPF termination without error",
-                       false);
-            return;
-        }
-        assertThat(translatedUpfTerminationRule, equalTo(expected));
-    }
-
-    @Test
     public void fabricEntryToUplinkUpfTerminationDropTest() {
         UpfTerminationUplink translatedUpfTerminationRule;
         UpfTerminationUplink expected = TestUpfConstants.UPLINK_UPF_TERMINATION_DROP;
@@ -137,22 +121,6 @@ public class FabricUpfTranslatorTest {
         try {
             translatedUpfTerminationRule = upfTranslator
                     .fabricEntryToUpfTerminationDownlink(TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION);
-        } catch (UpfProgrammableException e) {
-            assertThat("Fabric downlink UPF termination rule should correctly " +
-                               "translate to abstract UPF termination without error",
-                       false);
-            return;
-        }
-        assertThat(translatedUpfTerminationRule, equalTo(expected));
-    }
-
-    @Test
-    public void fabricEntryToDownlinkUpfTerminationNoTcTest() {
-        UpfTerminationDownlink translatedUpfTerminationRule;
-        UpfTerminationDownlink expected = TestUpfConstants.DOWNLINK_UPF_TERMINATION_NO_TC;
-        try {
-            translatedUpfTerminationRule = upfTranslator
-                    .fabricEntryToUpfTerminationDownlink(TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC);
         } catch (UpfProgrammableException e) {
             assertThat("Fabric downlink UPF termination rule should correctly " +
                                "translate to abstract UPF termination without error",
@@ -266,6 +234,22 @@ public class FabricUpfTranslatorTest {
 //        }
 //        assertThat(translatedMeter, equalTo(expectedResetMeter));
     }
+
+    @Test
+    public void fabricMeterToSliceMeterTest() {
+        UpfMeter translatedMeter;
+        UpfMeter expectedMeter = TestUpfConstants.SLICE_METER;
+        try {
+            translatedMeter = upfTranslator.fabricMeterToSliceMeter(
+                    TestUpfConstants.FABRIC_SLICE_METER);
+        } catch (UpfProgrammableException e) {
+            assertThat("Fabric slice meter should correctly translate to abstract UPF meter without error",
+                       false);
+            return;
+        }
+        assertThat(translatedMeter, equalTo(expectedMeter));
+    }
+
     // -------------------------------------------------------------------------
     @Test
     public void uplinkInterfaceToFabricEntryTest() {
@@ -405,26 +389,6 @@ public class FabricUpfTranslatorTest {
     }
 
     @Test
-    public void uplinkUpfTerminationNoTcToFabricEntryTest() {
-        FlowRule translatedRule;
-        FlowRule expectedRule = TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_NO_TC;
-        try {
-            translatedRule = upfTranslator.upfTerminationUplinkToFabricEntry(
-                    TestUpfConstants.UPLINK_UPF_TERMINATION_NO_TC,
-                    TestUpfConstants.DEVICE_ID,
-                    TestUpfConstants.APP_ID,
-                    TestUpfConstants.DEFAULT_PRIORITY);
-        } catch (UpfProgrammableException e) {
-            assertThat("Abstract uplink UPF Termination should correctly " +
-                               "translate to Fabric UPF Termination without error",
-                       false);
-            return;
-        }
-        assertThat(translatedRule, equalTo(expectedRule));
-        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
-    }
-
-    @Test
     public void uplinkUpfTerminationDropToFabricEntryTest() {
         FlowRule translatedRule;
         FlowRule expectedRule = TestUpfConstants.FABRIC_UPLINK_UPF_TERMINATION_DROP;
@@ -484,26 +448,6 @@ public class FabricUpfTranslatorTest {
     }
 
     @Test
-    public void downlinkUpfTerminationNoTcToFabricEntryTest() {
-        FlowRule translatedRule;
-        FlowRule expectedRule = TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC;
-        try {
-            translatedRule = upfTranslator.upfTerminationDownlinkToFabricEntry(
-                    TestUpfConstants.DOWNLINK_UPF_TERMINATION_NO_TC,
-                    TestUpfConstants.DEVICE_ID,
-                    TestUpfConstants.APP_ID,
-                    TestUpfConstants.DEFAULT_PRIORITY);
-        } catch (UpfProgrammableException e) {
-            assertThat("Abstract downlink UPF Termination should correctly " +
-                               "translate to Fabric UPF Termination without error",
-                       false);
-            return;
-        }
-        assertThat(translatedRule, equalTo(expectedRule));
-        assertThat(translatedRule.treatment(), equalTo(expectedRule.treatment()));
-    }
-
-    @Test
     public void downlinkUpfTerminationDropToFabricEntryTest() {
         FlowRule translatedRule;
         FlowRule expectedRule = TestUpfConstants.FABRIC_DOWNLINK_UPF_TERMINATION_DROP;
@@ -539,12 +483,7 @@ public class FabricUpfTranslatorTest {
             return;
         }
         // TODO: should we implement equals for DefaultMeterRequest?
-        assertThat(translatedMeter.appId(), equalTo(expectedMeter.appId()));
-        assertThat(translatedMeter.deviceId(), equalTo(expectedMeter.deviceId()));
-        assertThat(translatedMeter.isBurst(), equalTo(expectedMeter.isBurst()));
-        assertThat(translatedMeter.scope(), equalTo(expectedMeter.scope()));
-        assertThat(translatedMeter.index(), equalTo(expectedMeter.index()));
-        assertThat(translatedMeter.bands(), equalTo(expectedMeter.bands()));
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
     }
 
     @Test
@@ -563,12 +502,7 @@ public class FabricUpfTranslatorTest {
             return;
         }
         // TODO: should we implement equals for DefaultMeterRequest?
-        assertThat(translatedMeter.appId(), equalTo(expectedMeter.appId()));
-        assertThat(translatedMeter.deviceId(), equalTo(expectedMeter.deviceId()));
-        assertThat(translatedMeter.isBurst(), equalTo(expectedMeter.isBurst()));
-        assertThat(translatedMeter.scope(), equalTo(expectedMeter.scope()));
-        assertThat(translatedMeter.index(), equalTo(expectedMeter.index()));
-        assertThat(translatedMeter.bands(), equalTo(expectedMeter.bands()));
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
     }
 
     @Test
@@ -587,12 +521,7 @@ public class FabricUpfTranslatorTest {
             return;
         }
         // TODO: should we implement equals for DefaultMeterRequest?
-        assertThat(translatedMeter.appId(), equalTo(expectedMeter.appId()));
-        assertThat(translatedMeter.deviceId(), equalTo(expectedMeter.deviceId()));
-        assertThat(translatedMeter.isBurst(), equalTo(expectedMeter.isBurst()));
-        assertThat(translatedMeter.scope(), equalTo(expectedMeter.scope()));
-        assertThat(translatedMeter.index(), equalTo(expectedMeter.index()));
-        assertThat(translatedMeter.bands(), equalTo(expectedMeter.bands()));
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
     }
 
     @Test
@@ -611,11 +540,53 @@ public class FabricUpfTranslatorTest {
             return;
         }
         // TODO: should we implement equals for DefaultMeterRequest?
-        assertThat(translatedMeter.appId(), equalTo(expectedMeter.appId()));
-        assertThat(translatedMeter.deviceId(), equalTo(expectedMeter.deviceId()));
-        assertThat(translatedMeter.isBurst(), equalTo(expectedMeter.isBurst()));
-        assertThat(translatedMeter.scope(), equalTo(expectedMeter.scope()));
-        assertThat(translatedMeter.index(), equalTo(expectedMeter.index()));
-        assertThat(translatedMeter.bands(), equalTo(expectedMeter.bands()));
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
+    }
+
+    @Test
+    public void sliceMeterToFabricMeterTest() {
+        MeterRequest translatedMeter;
+        MeterRequest expectedMeter = TestUpfConstants.FABRIC_SLICE_METER_REQUEST;
+        try {
+            translatedMeter = upfTranslator.upfMeterToFabricMeter(
+                    TestUpfConstants.SLICE_METER,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract slice meter should correctly " +
+                               "translate to Fabric slice meter without error",
+                       false);
+            return;
+        }
+        // TODO: should we implement equals for DefaultMeterRequest?
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
+    }
+
+    @Test
+    public void sliceMeterResetToFabricMeterResetTest() {
+        MeterRequest translatedMeter;
+        MeterRequest expectedMeter = TestUpfConstants.FABRIC_SLICE_METER_RESET_REQUEST;
+        try {
+            translatedMeter = upfTranslator.upfMeterToFabricMeter(
+                    TestUpfConstants.SLICE_METER_RESET,
+                    TestUpfConstants.DEVICE_ID,
+                    TestUpfConstants.APP_ID);
+        } catch (UpfProgrammableException e) {
+            assertThat("Abstract slice meter should correctly " +
+                               "translate to Fabric slice meter without error",
+                       false);
+            return;
+        }
+        // TODO: should we implement equals for DefaultMeterRequest?
+        assertMeterRequestEqual(translatedMeter, expectedMeter);
+    }
+
+    private void assertMeterRequestEqual(MeterRequest actual, MeterRequest expected) {
+        assertThat(actual.appId(), equalTo(expected.appId()));
+        assertThat(actual.deviceId(), equalTo(expected.deviceId()));
+        assertThat(actual.isBurst(), equalTo(expected.isBurst()));
+        assertThat(actual.scope(), equalTo(expected.scope()));
+        assertThat(actual.index(), equalTo(expected.index()));
+        assertThat(actual.bands(), equalTo(expected.bands()));
     }
 }

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
@@ -42,13 +42,12 @@ import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.APP_METER_
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.CTR_ID;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_EG_TUNNEL_PEERS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_LOAD_TUNNEL_PARAMS;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_QOS_SLICE_TC_METER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APPLICATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APP_FWD;
-import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APP_FWD_NO_TC;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APP_METER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_DROP;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_FWD_ENCAP;
-import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_FWD_ENCAP_NO_TC;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_SESSIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_DOWNLINK_TERMINATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_IFACE_ACCESS;
@@ -118,6 +117,8 @@ public final class TestUpfConstants {
     public static final int PHYSICAL_MAX_UPF_TERMINATIONS = 512;
     public static final int PHYSICAL_MAX_TUNNELS = 256;
     public static final int PHYSICAL_MAX_APPLICATIONS = 5;
+    public static final int PHYSICAL_MAX_SLICE_METERS = 1 << 6;
+
 
     public static final long COUNTER_BYTES = 12;
     public static final long COUNTER_PKTS = 15;
@@ -170,11 +171,6 @@ public final class TestUpfConstants {
             .withAppMeterIdx(METER_CELL_ID)
             .build();
 
-    public static final UpfTerminationUplink UPLINK_UPF_TERMINATION_NO_TC = UpfTerminationUplink.builder()
-            .withUeSessionId(UE_ADDR)
-            .withCounterId(UPLINK_COUNTER_CELL_ID)
-            .build();
-
     public static final UpfTerminationUplink UPLINK_UPF_TERMINATION_DROP = UpfTerminationUplink.builder()
             .withUeSessionId(UE_ADDR)
             .withCounterId(UPLINK_COUNTER_CELL_ID)
@@ -207,13 +203,6 @@ public final class TestUpfConstants {
             .withSliceId(0)
             .build();
 
-    public static final UpfTerminationDownlink DOWNLINK_UPF_TERMINATION_NO_TC = UpfTerminationDownlink.builder()
-            .withUeSessionId(UE_ADDR)
-            .withCounterId(DOWNLINK_COUNTER_CELL_ID)
-            .withTeid(TEID_VALUE_QOS)
-            .withQfi(DOWNLINK_QFI)
-            .build();
-
     public static final UpfTerminationDownlink DOWNLINK_UPF_TERMINATION_DROP = UpfTerminationDownlink.builder()
             .withUeSessionId(UE_ADDR)
             .withCounterId(DOWNLINK_COUNTER_CELL_ID)
@@ -240,6 +229,14 @@ public final class TestUpfConstants {
             .build();
 
     public static final UpfMeter SESSION_METER_RESET = UpfMeter.resetSession(METER_CELL_ID);
+
+    public static final UpfMeter SLICE_METER = UpfMeter.builder()
+            .setSlice()
+            .setCellId(METER_CELL_ID)
+            .setPeakBand(PIR, PBURST)
+            .build();
+
+    public static final UpfMeter SLICE_METER_RESET = UpfMeter.resetSlice(METER_CELL_ID);
 
     public static final FlowRule FABRIC_INGRESS_GTP_TUNNEL_PEER = DefaultFlowRule.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
@@ -349,27 +346,6 @@ public final class TestUpfConstants {
             .withPriority(DEFAULT_PRIORITY)
             .build();
 
-    public static final FlowRule FABRIC_UPLINK_UPF_TERMINATION_NO_TC = DefaultFlowRule.builder()
-            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
-            .forTable(FABRIC_INGRESS_UPF_UPLINK_TERMINATIONS)
-            .withSelector(DefaultTrafficSelector.builder()
-                      .matchPi(PiCriterion.builder()
-                               // we don't match on slice_id, because we assume distinct UE pools per slice
-                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
-                               .matchExact(HDR_APP_ID, DEFAULT_APP_ID)
-                               .build()).build())
-            .withTreatment(DefaultTrafficTreatment.builder()
-                                   .piTableAction(PiAction.builder()
-                                                          .withId(FABRIC_INGRESS_UPF_APP_FWD_NO_TC)
-                                                          .withParameters(Arrays.asList(
-                                                                  new PiActionParam(CTR_ID, UPLINK_COUNTER_CELL_ID),
-                                                                  new PiActionParam(APP_METER_IDX,
-                                                                                    DEFAULT_APP_METER_IDX)
-                                                          ))
-                                                          .build()).build())
-            .withPriority(DEFAULT_PRIORITY)
-            .build();
-
     public static final FlowRule FABRIC_UPLINK_UPF_TERMINATION_DROP = DefaultFlowRule.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
             .forTable(FABRIC_INGRESS_UPF_UPLINK_TERMINATIONS)
@@ -409,29 +385,6 @@ public final class TestUpfConstants {
                                     new PiActionParam(APP_METER_IDX, (short) METER_CELL_ID)
                             ))
                             .build()).build())
-            .withPriority(DEFAULT_PRIORITY)
-            .build();
-
-    public static final FlowRule FABRIC_DOWNLINK_UPF_TERMINATION_NO_TC = DefaultFlowRule.builder()
-            .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
-            .forTable(FABRIC_INGRESS_UPF_DOWNLINK_TERMINATIONS)
-            .withSelector(DefaultTrafficSelector.builder()
-                      .matchPi(PiCriterion.builder()
-                               // we don't match on slice_id, because we assume distinct UE pools per slice
-                               .matchExact(HDR_UE_SESSION_ID, UE_ADDR.toInt())
-                               .matchExact(HDR_APP_ID, DEFAULT_APP_ID)
-                               .build()).build())
-            .withTreatment(DefaultTrafficTreatment.builder()
-                                   .piTableAction(PiAction.builder()
-                                                          .withId(FABRIC_INGRESS_UPF_DOWNLINK_FWD_ENCAP_NO_TC)
-                                                          .withParameters(Arrays.asList(
-                                                                  new PiActionParam(CTR_ID, DOWNLINK_COUNTER_CELL_ID),
-                                                                  new PiActionParam(TEID, TEID_VALUE_QOS),
-                                                                  new PiActionParam(QFI, DOWNLINK_QFI),
-                                                                  new PiActionParam(APP_METER_IDX,
-                                                                                    DEFAULT_APP_METER_IDX)
-                                                          ))
-                                                          .build()).build())
             .withPriority(DEFAULT_PRIORITY)
             .build();
 
@@ -573,6 +526,34 @@ public final class TestUpfConstants {
             .forDevice(DEVICE_ID).fromApp(APP_ID)
             .withIndex((long) METER_CELL_ID)
             .withScope(MeterScope.of(FABRIC_INGRESS_UPF_APP_METER.id()))
+            .withUnit(BYTES_PER_SEC)
+            .remove();
+
+    public static final Meter FABRIC_SLICE_METER = DefaultMeter.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID)
+            .withCellId(PiMeterCellId.ofIndirect(FABRIC_INGRESS_QOS_SLICE_TC_METER, METER_CELL_ID))
+            .withBands(Lists.newArrayList(
+                    DefaultBand.builder().ofType(Band.Type.MARK_RED).withRate(PIR).burstSize(PBURST).build(),
+                    DefaultBand.builder().ofType(Band.Type.MARK_YELLOW).withRate(0).burstSize(0).build()
+            ))
+            .withUnit(BYTES_PER_SEC)
+            .build();
+
+    public static final MeterRequest FABRIC_SLICE_METER_REQUEST = DefaultMeterRequest.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID)
+            .withIndex((long) METER_CELL_ID)
+            .withScope(MeterScope.of(FABRIC_INGRESS_QOS_SLICE_TC_METER.id()))
+            .withUnit(BYTES_PER_SEC)
+            .withBands(Lists.newArrayList(
+                    DefaultBand.builder().ofType(Band.Type.MARK_RED).withRate(PIR).burstSize(PBURST).build(),
+                    DefaultBand.builder().ofType(Band.Type.MARK_YELLOW).withRate(0).burstSize(0).build()
+            ))
+            .add();
+
+    public static final MeterRequest FABRIC_SLICE_METER_RESET_REQUEST = DefaultMeterRequest.builder()
+            .forDevice(DEVICE_ID).fromApp(APP_ID)
+            .withIndex((long) METER_CELL_ID)
+            .withScope(MeterScope.of(FABRIC_INGRESS_QOS_SLICE_TC_METER.id()))
             .withUnit(BYTES_PER_SEC)
             .remove();
 

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
@@ -91,6 +91,7 @@ public final class TestUpfConstants {
     public static final ApplicationId APP_ID = new DefaultApplicationId(5000, "up4");
     public static final int DEFAULT_PRIORITY = 10;
     public static final int SLICE_MOBILE = 10;
+    public static final byte ELASTIC_TC = 3;
     private static final byte DEFAULT_TC = 0;
     public static final int UPLINK_COUNTER_CELL_ID = 1;
     public static final int DOWNLINK_COUNTER_CELL_ID = 2;
@@ -131,6 +132,9 @@ public final class TestUpfConstants {
     public static final byte APP_IP_PROTO = 6;
 
     public static final int METER_CELL_ID = 10;
+    public static final int SLICE_METER_CELL_ID = (SLICE_MOBILE << 2) + (ELASTIC_TC & 0b11);
+    public static final int INVALID_SLICE_SLICE_METER_CELL_ID = ELASTIC_TC & 0b11;
+    public static final int INVALID_TC_SLICE_METER_CELL_ID = (SLICE_MOBILE << 2);
     public static final short DEFAULT_APP_METER_IDX = 0;
     public static final int PIR = 10000;
     public static final int PBURST = 1000;
@@ -232,11 +236,23 @@ public final class TestUpfConstants {
 
     public static final UpfMeter SLICE_METER = UpfMeter.builder()
             .setSlice()
-            .setCellId(METER_CELL_ID)
+            .setCellId(SLICE_METER_CELL_ID)
             .setPeakBand(PIR, PBURST)
             .build();
 
-    public static final UpfMeter SLICE_METER_RESET = UpfMeter.resetSlice(METER_CELL_ID);
+    public static final UpfMeter SLICE_METER_INVALID_SLICE_ID = UpfMeter.builder()
+            .setSlice()
+            .setCellId(INVALID_SLICE_SLICE_METER_CELL_ID)
+            .setPeakBand(PIR, PBURST)
+            .build();
+
+    public static final UpfMeter SLICE_METER_INVALID_TC = UpfMeter.builder()
+            .setSlice()
+            .setCellId(INVALID_TC_SLICE_METER_CELL_ID)
+            .setPeakBand(PIR, PBURST)
+            .build();
+
+    public static final UpfMeter SLICE_METER_RESET = UpfMeter.resetSlice(SLICE_METER_CELL_ID);
 
     public static final FlowRule FABRIC_INGRESS_GTP_TUNNEL_PEER = DefaultFlowRule.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
@@ -531,7 +547,7 @@ public final class TestUpfConstants {
 
     public static final Meter FABRIC_SLICE_METER = DefaultMeter.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID)
-            .withCellId(PiMeterCellId.ofIndirect(FABRIC_INGRESS_QOS_SLICE_TC_METER, METER_CELL_ID))
+            .withCellId(PiMeterCellId.ofIndirect(FABRIC_INGRESS_QOS_SLICE_TC_METER, SLICE_METER_CELL_ID))
             .withBands(Lists.newArrayList(
                     DefaultBand.builder().ofType(Band.Type.MARK_RED).withRate(PIR).burstSize(PBURST).build(),
                     DefaultBand.builder().ofType(Band.Type.MARK_YELLOW).withRate(0).burstSize(0).build()
@@ -541,7 +557,7 @@ public final class TestUpfConstants {
 
     public static final MeterRequest FABRIC_SLICE_METER_REQUEST = DefaultMeterRequest.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID)
-            .withIndex((long) METER_CELL_ID)
+            .withIndex((long) SLICE_METER_CELL_ID)
             .withScope(MeterScope.of(FABRIC_INGRESS_QOS_SLICE_TC_METER.id()))
             .withUnit(BYTES_PER_SEC)
             .withBands(Lists.newArrayList(
@@ -552,7 +568,7 @@ public final class TestUpfConstants {
 
     public static final MeterRequest FABRIC_SLICE_METER_RESET_REQUEST = DefaultMeterRequest.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID)
-            .withIndex((long) METER_CELL_ID)
+            .withIndex((long) SLICE_METER_CELL_ID)
             .withScope(MeterScope.of(FABRIC_INGRESS_QOS_SLICE_TC_METER.id()))
             .withUnit(BYTES_PER_SEC)
             .remove();


### PR DESCRIPTION
Allow setting slice TC meter via UpfProgrammable APIs.
Also, remove the `no_tc` apps, now TC is mandatory and we don't rely on `default_tc` in the physical pipeline.
Depends on:
- https://gerrit.onosproject.org/c/onos/+/25410