### PR TITLE
Skip FabricIntMulticastReportTest for bmv2

### DIFF
--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -2331,6 +2331,7 @@ class FabricIntQueueReportQuotaTest(IntTest):
 
 
 @group("int")
+@skipIf(is_v1model(), "Skip for bmv2")
 class FabricIntMulticastReportTest(IntTest, IPv4MulticastTest):
     @tvsetup
     @autocleanup

--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -2331,7 +2331,7 @@ class FabricIntQueueReportQuotaTest(IntTest):
 
 
 @group("int")
-@skipIf(is_v1model(), "Skip for bmv2")
+@skipIf(is_v1model(), "Skip for bmv2, see issue #507")
 class FabricIntMulticastReportTest(IntTest, IPv4MulticastTest):
     @tvsetup
     @autocleanup


### PR DESCRIPTION
Sometimes PTF framework won't be able to capture the INT report packet from stratum_bmv2.

Tracking this issue with #507