### PR TITLE
[SDFAB-1100] Leverage in-order FlowRuleService APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ multiple targets:
 To build and test this project you will need the following software:
 
 * Barefoot SDE (a.k.a. Intel P4 Studio) = 9.7.0
-* ONOS >= 2.5.7
+* ONOS >= 2.5.8
 * Docker (to run the build scripts without worrying about dependencies)
 * cURL (to interact with the ONOS REST APIs)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     <parent>
         <groupId>org.onosproject</groupId>
         <artifactId>onos-dependencies</artifactId>
-        <version>2.5.7-SNAPSHOT</version>
+        <version>2.5.8-SNAPSHOT</version>
     </parent>
 
     <groupId>org.stratumproject</groupId>

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockFlowRuleService.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockFlowRuleService.java
@@ -66,6 +66,16 @@ public class MockFlowRuleService extends FlowRuleServiceAdapter {
     }
 
     @Override
+    public void applyFlowRules(int key, FlowRule... flowRules) {
+        applyFlowRules(flowRules);
+    }
+
+    @Override
+    public void removeFlowRules(int key, FlowRule... flowRules) {
+        removeFlowRules(flowRules);
+    }
+
+    @Override
     public int getFlowRuleCount() {
         return flows.size();
     }


### PR DESCRIPTION
`FabricUpfProgrammable` leverages the new APIs to guarantee in-order processing of the requests coming from the north.

If batch APIs are not used there is no guarantee about the processing order in the `FlowRuleService`. Instead, the `striped` API allow the apps to signal a preference in the requests processing which is used by the `FlowRuleService` to serialize
all the requests, having equal key, on the same executor.

Depends on https://gerrit.onosproject.org/c/onos/+/25423