### PR TITLE
Update black and isort, and hardcode click packages for prettify

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -8,7 +8,7 @@ set -e
 python3 -m venv .venv
 # shellcheck disable=SC1091
 source .venv/bin/activate
-python3 -m pip install black==19.10b0 isort==5.6.4
+python3 -m pip install black==21.12b0 isort==5.10.1 click==8.0.4
 black --config .github/linters/.python-black .
 isort --sp .github/linters/.isort.cfg .
 deactivate

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -27,12 +27,6 @@ pipeline {
         stage("Prepare environment") {
             steps {
                 step([$class: "WsCleanup"])
-                sh """sudo bash -c 'cat << EOF > /etc/docker/daemon.json
-{
-    \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"]
-}
-EOF'"""
-                sh "sudo systemctl restart docker"
                 gitCheckout(GITHUB_URL, commitHash)
                 dockerLogins()
                 //Set JDK 11

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -27,6 +27,12 @@ pipeline {
         stage("Prepare environment") {
             steps {
                 step([$class: "WsCleanup"])
+                sh "cat << EOF > /etc/docker/daemon.json\
+                    { \
+                        \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"] \
+                    } \
+                    EOF"
+                sh "systemctl restart docker"
                 gitCheckout(GITHUB_URL, commitHash)
                 dockerLogins()
                 //Set JDK 11

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"]
 }
 EOF'"""
-                sh "systemctl restart docker"
+                sh "sudo systemctl restart docker"
                 gitCheckout(GITHUB_URL, commitHash)
                 dockerLogins()
                 //Set JDK 11

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -27,11 +27,11 @@ pipeline {
         stage("Prepare environment") {
             steps {
                 step([$class: "WsCleanup"])
-                sh "cat << EOF > /etc/docker/daemon.json\
+                sh "sudo bash -c 'cat << EOF > /etc/docker/daemon.json\
                     { \
                         \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"] \
                     } \
-                    EOF"
+                    EOF'"
                 sh "systemctl restart docker"
                 gitCheckout(GITHUB_URL, commitHash)
                 dockerLogins()

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -27,11 +27,11 @@ pipeline {
         stage("Prepare environment") {
             steps {
                 step([$class: "WsCleanup"])
-                sh "sudo bash -c 'cat << EOF > /etc/docker/daemon.json\
-                    { \
-                        \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"] \
-                    } \
-                    EOF'"
+                sh """sudo bash -c 'cat << EOF > /etc/docker/daemon.json
+{
+    \"registry-mirrors\":[\"https://mirror.registry.opennetworking.org\"]
+}
+EOF'"""
                 sh "systemctl restart docker"
                 gitCheckout(GITHUB_URL, commitHash)
                 dockerLogins()

--- a/ptf/tests/common/base_test.py
+++ b/ptf/tests/common/base_test.py
@@ -1059,7 +1059,8 @@ class P4RuntimeTest(BaseTest):
                 pre_entry = entity.packet_replication_engine_entry
                 if pre_entry.HasField("multicast_group_entry"):
                     self.verify_p4runtime_entity(
-                        pre_entry.multicast_group_entry, expected_multicast_group,
+                        pre_entry.multicast_group_entry,
+                        expected_multicast_group,
                     )
 
     def verify_direct_counter(
@@ -1093,7 +1094,12 @@ class P4RuntimeTest(BaseTest):
         return None
 
     def verify_indirect_counter(
-        self, c_name, c_index, typ, expected_byte_count=0, expected_packet_count=0,
+        self,
+        c_name,
+        c_index,
+        typ,
+        expected_byte_count=0,
+        expected_packet_count=0,
     ):
         # Check counter type with P4Info
         counter = self.get_counter(c_name)
@@ -1150,7 +1156,10 @@ class P4RuntimeTest(BaseTest):
         return None
 
     def verify_register(
-        self, register_name, register_index, expected_value,
+        self,
+        register_name,
+        register_index,
+        expected_value,
     ):
         req = self.get_new_read_request()
         entity = req.entities.add()
@@ -1347,7 +1356,10 @@ def tvcreate(name):
             finally:
                 if test.generate_tv:
                     tv_folder = os.path.join(
-                        os.getcwd(), "testvectors", test.__class__.__name__, sub_dir,
+                        os.getcwd(),
+                        "testvectors",
+                        test.__class__.__name__,
+                        sub_dir,
                     )
                     tvutils.write_to_file(
                         test.tv, tv_folder, tv_name, create_tv_sub_dir=False

--- a/ptf/tests/common/fabric_test.py
+++ b/ptf/tests/common/fabric_test.py
@@ -612,7 +612,14 @@ def pkt_add_gtp(
 ):
     gtp_pkt = (
         Ether(src=pkt[Ether].src, dst=pkt[Ether].dst)
-        / IP(src=out_ipv4_src, dst=out_ipv4_dst, tos=0, id=0x1513, flags=0, frag=0,)
+        / IP(
+            src=out_ipv4_src,
+            dst=out_ipv4_dst,
+            tos=0,
+            id=0x1513,
+            flags=0,
+            frag=0,
+        )
         / UDP(sport=sport, dport=dport, chksum=0)
         / GTP_U_Header(gtp_type=255, teid=teid)
     )
@@ -1200,10 +1207,14 @@ class FabricTest(P4RuntimeTest):
             )
             self.set_egress_vlan(port, DEFAULT_VLAN, push_vlan=False)
             self.set_forwarding_type(
-                port, ethertype=ETH_TYPE_IPV4, fwd_type=FORWARDING_TYPE_UNICAST_IPV4,
+                port,
+                ethertype=ETH_TYPE_IPV4,
+                fwd_type=FORWARDING_TYPE_UNICAST_IPV4,
             )
             self.set_forwarding_type(
-                port, ethertype=ETH_TYPE_MPLS_UNICAST, fwd_type=FORWARDING_TYPE_MPLS,
+                port,
+                ethertype=ETH_TYPE_MPLS_UNICAST,
+                fwd_type=FORWARDING_TYPE_MPLS,
             )
 
     def add_bridging_entry(
@@ -1346,7 +1357,12 @@ class FabricTest(P4RuntimeTest):
         )
 
     def add_forwarding_acl_drop(
-        self, ipv4_src=None, ipv4_dst=None, ip_proto=None, l4_sport=None, l4_dport=None,
+        self,
+        ipv4_src=None,
+        ipv4_dst=None,
+        ip_proto=None,
+        l4_sport=None,
+        l4_dport=None,
     ):
         # Send only if the match keys are not empty
         matches = self.build_acl_matches(
@@ -1354,7 +1370,11 @@ class FabricTest(P4RuntimeTest):
         )
         if matches:
             self.send_request_add_entry_to_action(
-                "acl.acl", matches, "acl.drop", [], DEFAULT_PRIORITY,
+                "acl.acl",
+                matches,
+                "acl.drop",
+                [],
+                DEFAULT_PRIORITY,
             )
 
     def build_acl_matches(
@@ -1569,7 +1589,9 @@ class FabricTest(P4RuntimeTest):
             "pre_next.next_mpls",
             [self.Exact("next_id", next_id_)],
             "pre_next.set_mpls_label",
-            [("label", label_),],
+            [
+                ("label", label_),
+            ],
         )
 
     # next_hops is a list of tuples (egress_port, smac, dmac)
@@ -1590,7 +1612,11 @@ class FabricTest(P4RuntimeTest):
                 actions.append(
                     [
                         "next.routing_hashed",
-                        [("port_num", egress_port_), ("smac", smac_), ("dmac", dmac_),],
+                        [
+                            ("port_num", egress_port_),
+                            ("smac", smac_),
+                            ("dmac", dmac_),
+                        ],
                     ]
                 )
         self.add_next_hashed_group_action(next_id, grp_id, actions)
@@ -1647,7 +1673,10 @@ class FabricTest(P4RuntimeTest):
     def add_next_hashed_group_member(self, action_name, params):
         mbr_id = self.get_next_mbr_id()
         return self.send_request_add_member(
-            "FabricIngress.next.hashed_profile", mbr_id, action_name, params,
+            "FabricIngress.next.hashed_profile",
+            mbr_id,
+            action_name,
+            params,
         )
 
     def add_next_hashed_group(self, grp_id, mbr_ids):
@@ -1660,7 +1689,10 @@ class FabricTest(P4RuntimeTest):
 
     def modify_next_hashed_group(self, grp_id, mbr_ids, grp_size):
         return self.send_request_modify_group(
-            "FabricIngress.next.hashed_profile", grp_id, grp_size, mbr_ids,
+            "FabricIngress.next.hashed_profile",
+            grp_id,
+            grp_size,
+            mbr_ids,
         )
 
     def read_next_hashed_group_member(self, mbr_id):
@@ -2455,8 +2487,7 @@ class PacketInTest(FabricTest):
 
 
 class SlicingTest(FabricTest):
-    """Mixin class with methods to manipulate QoS entities
-    """
+    """Mixin class with methods to manipulate QoS entities"""
 
     def set_default_tc(self, slice_id=None, tc=None):
         matches = [
@@ -2507,7 +2538,12 @@ class SlicingTest(FabricTest):
         pir = int(peak_bps / 8)
         pburst = int(pir * BURST_DURATION_MS * 0.001)
         self.configure_slice_tc_meter(
-            slice_id=slice_id, tc=tc, cir=cir, cburst=cburst, pir=pir, pburst=pburst,
+            slice_id=slice_id,
+            tc=tc,
+            cir=cir,
+            cburst=cburst,
+            pir=pir,
+            pburst=pburst,
         )
 
     def add_queue_entry(self, slice_id, tc, qid=None, color=None):
@@ -2563,7 +2599,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
                 self.Exact("gtpu_is_valid", stringify(int(gtpu_valid))),
             ],
             "FabricIngress.upf." + iface_type,
-            [("slice_id", stringify(slice_id)),],
+            [
+                ("slice_id", stringify(slice_id)),
+            ],
         )
         self.write_request(req)
 
@@ -2646,7 +2684,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             "FabricIngress.upf.applications",
             match_fields,
             "FabricIngress.upf.set_app_id",
-            [("app_id", stringify(app_id)),],
+            [
+                ("app_id", stringify(app_id)),
+            ],
             priority=priority,
         )
         self.write_request(req)
@@ -2841,7 +2881,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             "FabricIngress.upf.ig_tunnel_peers",
             [self.Exact("tun_peer_id", stringify(tunnel_peer_id))],
             "FabricIngress.upf.set_routing_ipv4_dst",
-            [("tun_dst_addr", ipv4_to_binary(tunnel_dst_addr)),],
+            [
+                ("tun_dst_addr", ipv4_to_binary(tunnel_dst_addr)),
+            ],
         )
         self.write_request(req)
 
@@ -2914,7 +2956,10 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
 
     def enable_encap_with_psc(self):
         self.send_request_add_entry_to_action(
-            "FabricEgress.upf.gtpu_encap", None, "FabricEgress.upf.gtpu_with_psc", [],
+            "FabricEgress.upf.gtpu_encap",
+            None,
+            "FabricEgress.upf.gtpu_with_psc",
+            [],
         )
 
     def reset_upf_counters(self, ctr_idx):
@@ -2932,15 +2977,23 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
         exp_ingress_pkts,
         exp_egress_pkts,
     ):
-        """ Verify that the UPF ingress and egress counters for index 'ctr_idx' are now
-            'exp_ingress_bytes', 'exp_ingress_pkts' and 'exp_egress_bytes',
-            'exp_egress_pkts' respectively upon reading.
+        """Verify that the UPF ingress and egress counters for index 'ctr_idx' are now
+        'exp_ingress_bytes', 'exp_ingress_pkts' and 'exp_egress_bytes',
+        'exp_egress_pkts' respectively upon reading.
         """
         self.verify_indirect_counter(
-            UPF_COUNTER_INGRESS, ctr_idx, "BOTH", exp_ingress_bytes, exp_ingress_pkts,
+            UPF_COUNTER_INGRESS,
+            ctr_idx,
+            "BOTH",
+            exp_ingress_bytes,
+            exp_ingress_pkts,
         )
         self.verify_indirect_counter(
-            UPF_COUNTER_EGRESS, ctr_idx, "BOTH", exp_egress_bytes, exp_egress_pkts,
+            UPF_COUNTER_EGRESS,
+            ctr_idx,
+            "BOTH",
+            exp_egress_bytes,
+            exp_egress_pkts,
         )
 
     def runUplinkTest(
@@ -3009,7 +3062,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             )
         if meter_drop:
             self.enable_policing(
-                slice_id, tc, V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
+                slice_id,
+                tc,
+                V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
             )
         app_meter_idx = DEFAULT_APP_METER_IDX
         if app_max_bps is not None:
@@ -3291,7 +3346,9 @@ class UpfSimpleTest(IPv4UnicastTest, SlicingTest):
             )
         if meter_drop:
             self.enable_policing(
-                slice_id, tc, V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
+                slice_id,
+                tc,
+                V1MODEL_COLOR_RED if is_v1model() else COLOR_RED,
             )
         app_meter_idx = DEFAULT_APP_METER_IDX
         if app_max_bps is not None:
@@ -3696,7 +3753,11 @@ class IntTest(IPv4UnicastTest):
             matches.append(self.Range("l4_dport", dport_low, dport_high))
 
         self.send_request_add_entry_to_action(
-            "watchlist", matches, action, [], priority=DEFAULT_PRIORITY,
+            "watchlist",
+            matches,
+            action,
+            [],
+            priority=DEFAULT_PRIORITY,
         )
 
     def truncate_packet(self, pkt, size):
@@ -3746,7 +3807,9 @@ class IntTest(IPv4UnicastTest):
             / UDP(sport=0, chksum=0)
             / INT_L45_REPORT_FIXED(nproto=2, f=f_flag, q=q_flag, hw_id=(eg_port >> 7))
             / INT_L45_LOCAL_REPORT(
-                switch_id=sw_id, ingress_port_id=ig_port, egress_port_id=eg_port,
+                switch_id=sw_id,
+                ingress_port_id=ig_port,
+                egress_port_id=eg_port,
             )
             / inner_packet
         )
@@ -4809,7 +4872,14 @@ class PppoeTest(DoubleVlanTerminationTest):
         )
 
     def setup_line_v4(
-        self, s_tag, c_tag, line_id, ipv4_addr, mac_src, pppoe_session_id, enabled=True,
+        self,
+        s_tag,
+        c_tag,
+        line_id,
+        ipv4_addr,
+        mac_src,
+        pppoe_session_id,
+        enabled=True,
     ):
         assert s_tag != 0
         assert c_tag != 0
@@ -4907,7 +4977,10 @@ class PppoeTest(DoubleVlanTerminationTest):
 
         # Input is the given packet with double VLAN tags and PPPoE headers.
         pppoe_pkt = pkt_add_pppoe(
-            pkt, type=1, code=PPPOE_CODE_SESSION_STAGE, session_id=pppoe_session_id,
+            pkt,
+            type=1,
+            code=PPPOE_CODE_SESSION_STAGE,
+            session_id=pppoe_session_id,
         )
         pppoe_pkt = pkt_add_vlan(pppoe_pkt, vlan_vid=vlan_id_inner)
         pppoe_pkt = pkt_add_vlan(pppoe_pkt, vlan_vid=vlan_id_outer)
@@ -5030,7 +5103,10 @@ class PppoeTest(DoubleVlanTerminationTest):
         # Build expected packet from the input one, we expect it to be routed
         # and encapsulated in double VLAN tags and PPPoE.
         exp_pkt = pkt_add_pppoe(
-            pkt, type=1, code=PPPOE_CODE_SESSION_STAGE, session_id=pppoe_session_id,
+            pkt,
+            type=1,
+            code=PPPOE_CODE_SESSION_STAGE,
+            session_id=pppoe_session_id,
         )
         exp_pkt = pkt_add_vlan(exp_pkt, vlan_vid=vlan_id_outer)
         exp_pkt = pkt_add_inner_vlan(exp_pkt, vlan_vid=vlan_id_inner)
@@ -5135,7 +5211,12 @@ class StatsTest(FabricTest):
                 "Counter is not same as expected.\
                 \nActual packet count: %d, Expected packet count: %d\
                 \nActual byte count: %d, Expected byte count: %d\n"
-                % (actual_pkt_count, pkt_count, actual_byte_count, byte_count,)
+                % (
+                    actual_pkt_count,
+                    pkt_count,
+                    actual_byte_count,
+                    byte_count,
+                )
             )
 
     def add_stats_table_entry(self, gress, stats_flow_id, ports, **ftuple):

--- a/ptf/tests/common/ptf_runner.py
+++ b/ptf/tests/common/ptf_runner.py
@@ -114,7 +114,11 @@ def build_pipeline_config(pipeline_config_path):
 
 
 def update_config(
-    p4info_path, pipeline_config_path, grpc_addr, device_id, generate_tv=False,
+    p4info_path,
+    pipeline_config_path,
+    grpc_addr,
+    device_id,
+    generate_tv=False,
 ):
     """
     Performs a SetForwardingPipelineConfig on the device
@@ -384,7 +388,10 @@ def main():
         default="localhost:50051",
     )
     parser.add_argument(
-        "--device-id", help="Device id for device under test", type=int, default=1,
+        "--device-id",
+        help="Device id for device under test",
+        type=int,
+        default=1,
     )
     parser.add_argument(
         "--cpu-port",
@@ -393,10 +400,16 @@ def main():
         default=0xFFFFFFFD,
     )
     parser.add_argument(
-        "--ptf-dir", help="Directory containing PTF tests", type=str, required=True,
+        "--ptf-dir",
+        help="Directory containing PTF tests",
+        type=str,
+        required=True,
     )
     parser.add_argument(
-        "--port-map", help="Path to JSON port mapping", type=str, required=True,
+        "--port-map",
+        help="Path to JSON port mapping",
+        type=str,
+        required=True,
     )
     parser.add_argument(
         "--platform",
@@ -493,7 +506,9 @@ def main():
         trex_daemon_client = CTRexClient(args.trex_address, trex_args=trex_args)
         info("Starting TRex daemon client...")
         success = set_up_trex_server(
-            trex_daemon_client, args.trex_address, args.trex_config,
+            trex_daemon_client,
+            args.trex_address,
+            args.trex_config,
         )
         if not success:
             error("Failed to set up TRex daemon client!")

--- a/ptf/tests/common/trex_utils.py
+++ b/ptf/tests/common/trex_utils.py
@@ -107,7 +107,7 @@ def list_port_status(port_status: dict) -> None:
 
 def monitor_port_stats(c: STLClient, ports: []) -> dict:
     """
-    List some port stats continuously while traffic is active 
+    List some port stats continuously while traffic is active
 
     :parameters:
     c: STLClient
@@ -216,7 +216,14 @@ LatencyStats = collections.namedtuple(
 )
 
 FlowStats = collections.namedtuple(
-    "FlowStats", ["pg_id", "tx_packets", "rx_packets", "tx_bytes", "rx_bytes",],
+    "FlowStats",
+    [
+        "pg_id",
+        "tx_packets",
+        "rx_packets",
+        "tx_bytes",
+        "rx_bytes",
+    ],
 )
 
 FlowRateShares = collections.namedtuple(

--- a/ptf/tests/linerate/int_queue_report.py
+++ b/ptf/tests/linerate/int_queue_report.py
@@ -78,7 +78,9 @@ class IntQueueReportTest(TRexTest, IntTest, SlicingTest):
 
         # To avoid reporting INT report packet, we use queue ID 1 for the traffic.
         self.add_slice_tc_classifier_entry(
-            slice_id=SLICE_ID, tc=TC, ipv4_dst=pkt[IP].dst,
+            slice_id=SLICE_ID,
+            tc=TC,
+            ipv4_dst=pkt[IP].dst,
         )
         self.add_queue_entry(slice_id=SLICE_ID, tc=TC, qid=DEFAULT_QID)
 

--- a/ptf/tests/linerate/int_traffic_trace.py
+++ b/ptf/tests/linerate/int_traffic_trace.py
@@ -186,7 +186,8 @@ class IntIngressDropReportFilterWithTrafficTrace(TRexTest, IntTest):
         - Drop reason: All packets were dropped because of the installed ACL rule
         """
         self.failIf(
-            recv_packets > 0, f"ACL did not drop all packets, received {recv_packets}",
+            recv_packets > 0,
+            f"ACL did not drop all packets, received {recv_packets}",
         )
 
         accuracy_score = results["drop_accuracy_score"]

--- a/ptf/tests/linerate/meter_tests.py
+++ b/ptf/tests/linerate/meter_tests.py
@@ -131,7 +131,13 @@ class UpfPolicingTest(TRexTest, UpfSimpleTest, StatsTest):
 
     # Create a stream with GTP encapped traffic.
     def create_gtp_stream(
-        self, ue_addr, teid, pg_id=None, dport=None, l2_size=1400, l1_bps=None,
+        self,
+        ue_addr,
+        teid,
+        pg_id=None,
+        dport=None,
+        l2_size=1400,
+        l1_bps=None,
     ) -> STLStream:
         if dport is not None:
             pkt = simple_udp_packet(

--- a/ptf/tests/linerate/qos_tests.py
+++ b/ptf/tests/linerate/qos_tests.py
@@ -198,7 +198,11 @@ class QosTest(TRexTest, SlicingTest, StatsTest):
 
     # Create a lower priority best-effort stream.
     def create_best_effort_stream(
-        self, pg_id=None, dport=None, l2_size=None, l1_bps=None,
+        self,
+        pg_id=None,
+        dport=None,
+        l2_size=None,
+        l1_bps=None,
     ) -> STLStream:
         pkt = qos_utils.get_best_effort_traffic_packet(l2_size=l2_size, dport=dport)
         stats = None
@@ -830,7 +834,10 @@ class ElasticTrafficIsWrrScheduled(QosTest):
         print(get_readable_flow_stats(flow_stats_3))
 
         flow_rate_shares = get_flow_rate_shares(
-            TRAFFIC_DURATION_SECONDS, flow_stats_1, flow_stats_2, flow_stats_3,
+            TRAFFIC_DURATION_SECONDS,
+            flow_stats_1,
+            flow_stats_2,
+            flow_stats_3,
         )
         print(get_readable_flow_rate_shares(flow_rate_shares))
 

--- a/ptf/tests/unary/slicing.py
+++ b/ptf/tests/unary/slicing.py
@@ -10,8 +10,7 @@ from scapy.layers.inet import IP
 class FabricIPv4UnicastWithDscpClassificationAndRewriteTest(
     SlicingTest, IPv4UnicastTest
 ):
-    """Tests DSCP-based classification and rewrite.
-    """
+    """Tests DSCP-based classification and rewrite."""
 
     @tvsetup
     @autocleanup
@@ -250,7 +249,7 @@ class FabricUpfUplinkWithDscpRewriteTest(UpfSimpleTest, SlicingTest):
 class FabricUpfUplinkWithMeterTest(UpfSimpleTest):
     """Tests meters for UPF. This is mostly a dummmy test class to verify
     basic programming of UPF meters. QoS test for UPF meters and color-aware
-    meter behaviour should use linerate traffic generation. """
+    meter behaviour should use linerate traffic generation."""
 
     @tvsetup
     @autocleanup
@@ -279,7 +278,9 @@ class FabricUpfUplinkWithMeterTest(UpfSimpleTest):
                 for session_bps in [0, 100000]:
                     print(
                         "Testing pkt={}, app_bps={}, session_bps={}...".format(
-                            pkt_type, app_bps, session_bps,
+                            pkt_type,
+                            app_bps,
+                            session_bps,
                         )
                     )
                     pkt = getattr(testutils, "simple_%s_packet" % pkt_type)(
@@ -290,7 +291,9 @@ class FabricUpfUplinkWithMeterTest(UpfSimpleTest):
                         pktlen=MIN_PKT_LEN,
                     )
                     self.doRunTest(
-                        pkt=pkt, app_bps=app_bps, session_bps=session_bps,
+                        pkt=pkt,
+                        app_bps=app_bps,
+                        session_bps=session_bps,
                     )
 
 
@@ -298,7 +301,7 @@ class FabricUpfUplinkWithMeterTest(UpfSimpleTest):
 class FabricUpfDownlinkWithMeterTest(UpfSimpleTest):
     """Tests meters for UPF. This is mostly a dummmy test class to verify
     basic programming of UPF meters. QoS test for UPF meters and color-aware
-    meter behaviour should use linerate traffic generation. """
+    meter behaviour should use linerate traffic generation."""
 
     @tvsetup
     @autocleanup
@@ -327,7 +330,9 @@ class FabricUpfDownlinkWithMeterTest(UpfSimpleTest):
                 for session_bps in [0, 100000]:
                     print(
                         "Testing pkt={}, app_bps={}, session_bps={}...".format(
-                            pkt_type, app_bps, session_bps,
+                            pkt_type,
+                            app_bps,
+                            session_bps,
                         )
                     )
                     pkt = getattr(testutils, "simple_%s_packet" % pkt_type)(
@@ -338,13 +343,15 @@ class FabricUpfDownlinkWithMeterTest(UpfSimpleTest):
                         pktlen=MIN_PKT_LEN,
                     )
                     self.doRunTest(
-                        pkt=pkt, app_bps=app_bps, session_bps=session_bps,
+                        pkt=pkt,
+                        app_bps=app_bps,
+                        session_bps=session_bps,
                     )
 
 
 class FabricIPv4UnicastWithPolicingTest(SlicingTest, IPv4UnicastTest):
     """Tests QoS policer. This is mostly a dummmy test class to verify basic programming of
-    QoS-related entities. Most of the QoS tests should use linerate traffic generation. """
+    QoS-related entities. Most of the QoS tests should use linerate traffic generation."""
 
     @tvsetup
     @autocleanup
@@ -388,5 +395,8 @@ class FabricIPv4UnicastWithPolicingTest(SlicingTest, IPv4UnicastTest):
                     pktlen=MIN_PKT_LEN,
                 )
                 self.doRunTest(
-                    pkt=pkt, policing=policing, next_hop_mac=HOST2_MAC, tc_name=tc_name,
+                    pkt=pkt,
+                    policing=policing,
+                    next_hop_mac=HOST2_MAC,
+                    tc_name=tc_name,
                 )

--- a/ptf/tests/unary/stats.py
+++ b/ptf/tests/unary/stats.py
@@ -79,8 +79,7 @@ class StatsIPv4UnicastTest(StatsTest, IPv4UnicastTest):
 
 
 class FabricStatsIPv4UnicastTest(StatsIPv4UnicastTest):
-    """Tests stats counters for IPv4 unicast routing with different packet types
-    """
+    """Tests stats counters for IPv4 unicast routing with different packet types"""
 
     @tvsetup
     @autocleanup

--- a/ptf/tests/unary/test.py
+++ b/ptf/tests/unary/test.py
@@ -83,7 +83,8 @@ class FabricArpBroadcastUntaggedTest(ArpBroadcastTest):
     def runTest(self):
 
         self.runArpBroadcastTest(
-            tagged_ports=[], untagged_ports=[self.port1, self.port2, self.port3],
+            tagged_ports=[],
+            untagged_ports=[self.port1, self.port2, self.port3],
         )
 
 
@@ -93,7 +94,8 @@ class FabricArpBroadcastTaggedTest(ArpBroadcastTest):
     @autocleanup
     def runTest(self):
         self.runArpBroadcastTest(
-            tagged_ports=[self.port1, self.port2, self.port3], untagged_ports=[],
+            tagged_ports=[self.port1, self.port2, self.port3],
+            untagged_ports=[],
         )
 
 
@@ -132,7 +134,11 @@ class FabricIPv4UnicastTest(IPv4UnicastTest):
     @autocleanup
     def doRunTest(self, pkt, mac_dest, prefix_len, tagged1, tagged2, tc_name):
         self.runIPv4UnicastTest(
-            pkt, mac_dest, prefix_len=prefix_len, tagged1=tagged1, tagged2=tagged2,
+            pkt,
+            mac_dest,
+            prefix_len=prefix_len,
+            tagged1=tagged1,
+            tagged2=tagged2,
         )
 
     def runTest(self):
@@ -206,7 +212,10 @@ class FabricIPv4UnicastFromPacketOutTest(IPv4UnicastTest):
                     pktlen=MIN_PKT_LEN,
                 )
                 self.doRunTest(
-                    pkt=pkt, mac_dest=HOST2_MAC, tagged2=tagged2, tc_name=tc_name,
+                    pkt=pkt,
+                    mac_dest=HOST2_MAC,
+                    tagged2=tagged2,
+                    tc_name=tc_name,
                 )
 
 
@@ -218,7 +227,8 @@ class FabricIPv4UnicastDropTest(IPv4UnicastTest):
         self.setup_port(eg_port, 1, PORT_TYPE_EDGE)
         self.set_forwarding_type(ig_port, SWITCH_MAC)
         self.add_forwarding_routing_v4_drop(
-            ipv4_dstAddr=ipv4_dst, ipv4_pLen=ipv4_len,
+            ipv4_dstAddr=ipv4_dst,
+            ipv4_pLen=ipv4_len,
         )
         self.send_packet(ig_port, pkt)
         self.verify_no_other_packets()
@@ -248,7 +258,8 @@ class FabricIPv4DropWithACLOverrideRoutingTest(IPv4UnicastTest):
             next_id=400, ig_port_type=PORT_TYPE_EDGE, ipv4_dst=ipv4_dst
         )
         self.add_forwarding_routing_v4_drop(
-            ipv4_dstAddr=ipv4_dst, ipv4_pLen=ipv4_len,
+            ipv4_dstAddr=ipv4_dst,
+            ipv4_pLen=ipv4_len,
         )
         self.send_packet(ig_port, pkt)
         self.verify_packet(exp_pkt, eg_port)
@@ -277,7 +288,8 @@ class FabricIPv4DropWithACLOverrideOutputTest(IPv4UnicastTest):
         self.set_forwarding_type(ig_port, SWITCH_MAC)
         self.add_forwarding_acl_set_output_port(eg_port, ipv4_dst=ipv4_dst)
         self.add_forwarding_routing_v4_drop(
-            ipv4_dstAddr=ipv4_dst, ipv4_pLen=ipv4_len,
+            ipv4_dstAddr=ipv4_dst,
+            ipv4_pLen=ipv4_len,
         )
         self.send_packet(ig_port, pkt)
         self.verify_packet(exp_pkt, eg_port)
@@ -2007,7 +2019,13 @@ class FabricFlowReportFilterNoChangeTest(IntTest):
     @tvsetup
     @autocleanup
     def doRunTest(
-        self, vlan_conf, tagged, pkt_type, is_next_hop_spine, expect_int_report, ip_dst,
+        self,
+        vlan_conf,
+        tagged,
+        pkt_type,
+        is_next_hop_spine,
+        expect_int_report,
+        ip_dst,
     ):
         self.set_up_flow_report_filter_config(
             hop_latency_mask=0xF0000000, timestamp_mask=0
@@ -2129,7 +2147,13 @@ class FabricDropReportFilterTest(IntTest):
     @tvsetup
     @autocleanup
     def doRunTest(
-        self, vlan_conf, tagged, pkt_type, is_next_hop_spine, expect_int_report, ip_dst,
+        self,
+        vlan_conf,
+        tagged,
+        pkt_type,
+        is_next_hop_spine,
+        expect_int_report,
+        ip_dst,
     ):
         self.set_up_flow_report_filter_config(
             hop_latency_mask=0xF0000000, timestamp_mask=0
@@ -2254,7 +2278,11 @@ class FabricIntQueueReportQuotaTest(IntTest):
     @tvsetup
     @autocleanup
     def doRunTest(
-        self, expect_int_report, quota_left, threshold_trigger, threshold_reset,
+        self,
+        expect_int_report,
+        quota_left,
+        threshold_trigger,
+        threshold_reset,
     ):
         print(
             f"Testing expect_int_report={expect_int_report}, quota_left={quota_left}, "

--- a/util/gen-p4-constants.py
+++ b/util/gen-p4-constants.py
@@ -249,13 +249,16 @@ def gen_pkg_path(output, base_name):
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="gen-p4-constants.py", description="P4Info to Java constant generator.",
+        prog="gen-p4-constants.py",
+        description="P4Info to Java constant generator.",
     )
     parser.add_argument("name", help="Name of the constant, will be used as class name")
     parser.add_argument("p4info", help="P4Info file")
     parser.add_argument("-o", "--output", help="output path", default="-")
     parser.add_argument(
-        "--with-package-path", help="Specify the java package path", dest="pkg_path",
+        "--with-package-path",
+        help="Specify the java package path",
+        dest="pkg_path",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
This should solve the issue we recently see in post-merge prettify GHA.

Notes:
- black 21.12b0 is the latest supporting python2.7
- click 8.0.4 is required to run black < 22.3.0 (see: https://github.com/psf/black/issues/2964)