### PR TITLE
Allows to read ingress and egress counter separately

### DIFF
--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockP4RuntimeClient.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockP4RuntimeClient.java
@@ -1,0 +1,117 @@
+// Copyright 2022-present Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.stratumproject.fabric.tna.behaviour.upf;
+
+import com.google.common.collect.Maps;
+import org.onosproject.net.DeviceId;
+import org.onosproject.net.pi.model.PiPipeconf;
+import org.onosproject.net.pi.runtime.PiCounterCell;
+import org.onosproject.net.pi.runtime.PiCounterCellData;
+import org.onosproject.net.pi.runtime.PiCounterCellId;
+import org.onosproject.net.pi.runtime.PiPacketOperation;
+import org.onosproject.p4runtime.api.P4RuntimeClient;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.LongStream;
+
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER;
+
+/**
+ * Used to mock P4Runtime client used only for read/write requests for counters.
+ */
+public class MockP4RuntimeClient implements P4RuntimeClient {
+
+    private final DeviceId deviceId;
+    final Map<Long, PiCounterCell> igCounters;
+    final Map<Long, PiCounterCell> egCounters;
+
+    /**
+     * Used to mock P4Runtime client.
+     *
+     * @param deviceId    The ID of the device
+     * @param counterSize The size of the counter array
+     */
+    public MockP4RuntimeClient(DeviceId deviceId, int counterSize) {
+        this.deviceId = deviceId;
+        igCounters = Maps.newHashMap();
+        egCounters = Maps.newHashMap();
+        LongStream.range(0, counterSize).forEach(i -> {
+            igCounters.put(i, new PiCounterCell(
+                    PiCounterCellId.ofIndirect(FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER, i),
+                    new PiCounterCellData(0, 0)));
+            egCounters.put(i, new PiCounterCell(
+                    PiCounterCellId.ofIndirect(FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER, i),
+                    new PiCounterCellData(0, 0)));
+        });
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public boolean isServerReachable() {
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> probeService() {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPipelineConfig(long p4DeviceId, PiPipeconf pipeconf, ByteBuffer deviceData) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isPipelineConfigSet(long p4DeviceId, PiPipeconf pipeconf) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isAnyPipelineConfigSet(long p4DeviceId) {
+        return null;
+    }
+
+    @Override
+    public ReadRequest read(long p4DeviceId, PiPipeconf pipeconf) {
+        return new MockReadRequest(deviceId, igCounters, egCounters);
+    }
+
+    @Override
+    public void setMastership(long p4DeviceId, boolean master, BigInteger electionId) {
+
+    }
+
+    @Override
+    public boolean isSessionOpen(long p4DeviceId) {
+        return false;
+    }
+
+    @Override
+    public void closeSession(long p4DeviceId) {
+
+    }
+
+    @Override
+    public boolean isMaster(long p4DeviceId) {
+        return false;
+    }
+
+    @Override
+    public void packetOut(long p4DeviceId, PiPacketOperation packet, PiPipeconf pipeconf) {
+
+    }
+
+    @Override
+    public WriteRequest write(long p4DeviceId, PiPipeconf pipeconf) {
+        return new MockWriteRequest(deviceId, igCounters, egCounters);
+    }
+}

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockP4RuntimeController.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockP4RuntimeController.java
@@ -5,39 +5,26 @@ package org.stratumproject.fabric.tna.behaviour.upf;
 import io.grpc.ManagedChannel;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.device.DeviceAgentListener;
-import org.onosproject.net.pi.model.PiPipeconf;
 import org.onosproject.net.provider.ProviderId;
 import org.onosproject.p4runtime.api.P4RuntimeClient;
 import org.onosproject.p4runtime.api.P4RuntimeController;
 import org.onosproject.p4runtime.api.P4RuntimeEventListener;
 
-import static org.easymock.EasyMock.anyLong;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-
 /**
- * Currently only used to get mock clients that mock counter read requests.
+ * Currently only used to get mock clients that mock counter read/write requests.
  */
 public class MockP4RuntimeController implements P4RuntimeController {
 
-    private final P4RuntimeClient mockP4rtClient;
+    final MockP4RuntimeClient mockP4rtClient;
 
     /**
-     * Used to mock counter read requests.
+     * Used to mock counter read/write requests.
      *
-     * @param deviceId The ID of the device
-     * @param packets Packets counter value
-     * @param bytes Bytes counter value
+     * @param deviceId    The ID of the device
      * @param counterSize The size of the counter array
      */
-    public MockP4RuntimeController(DeviceId deviceId, long packets, long bytes, int counterSize) {
-        mockP4rtClient = createMock(P4RuntimeClient.class);
-        expect(mockP4rtClient.read(anyLong(), anyObject(PiPipeconf.class)))
-                .andReturn(new MockReadRequest(deviceId, packets, bytes, counterSize))
-                .anyTimes();
-        replay(mockP4rtClient);
+    public MockP4RuntimeController(DeviceId deviceId, int counterSize) {
+        mockP4rtClient = new MockP4RuntimeClient(deviceId, counterSize);
     }
 
     @Override

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockReadResponse.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockReadResponse.java
@@ -3,8 +3,8 @@
 package org.stratumproject.fabric.tna.behaviour.upf;
 
 import org.onosproject.net.pi.runtime.PiCounterCell;
-import org.onosproject.net.pi.runtime.PiCounterCellData;
 import org.onosproject.net.pi.runtime.PiCounterCellHandle;
+import org.onosproject.net.pi.runtime.PiCounterCellId;
 import org.onosproject.net.pi.runtime.PiEntity;
 import org.onosproject.net.pi.runtime.PiEntityType;
 import org.onosproject.net.pi.runtime.PiHandle;
@@ -13,8 +13,11 @@ import org.onosproject.p4runtime.api.P4RuntimeReadClient;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER;
 
 /**
  * For faking reads to a p4runtime client. Currently only used for testing
@@ -23,13 +26,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class MockReadResponse implements P4RuntimeReadClient.ReadResponse {
     List<PiEntity> entities;
-    long packets;
-    long bytes;
+    Map<Long, PiCounterCell> igCounters;
+    Map<Long, PiCounterCell> egCounters;
 
-    public MockReadResponse(Iterable<? extends PiHandle> handles, long packets, long bytes) {
+    public MockReadResponse(Iterable<? extends PiHandle> handles,
+                            Map<Long, PiCounterCell> igCounters,
+                            Map<Long, PiCounterCell> egCounters) {
         this.entities = new ArrayList<>();
-        this.packets = packets;
-        this.bytes = bytes;
+        this.igCounters = igCounters;
+        this.egCounters = egCounters;
         checkNotNull(handles);
         handles.forEach(this::handle);
     }
@@ -42,13 +47,20 @@ public class MockReadResponse implements P4RuntimeReadClient.ReadResponse {
     public MockReadResponse handle(PiHandle handle) {
         if (handle.entityType().equals(PiEntityType.COUNTER_CELL)) {
             PiCounterCellHandle counterHandle = (PiCounterCellHandle) handle;
-            PiCounterCellData data =
-                    new PiCounterCellData(this.packets, this.bytes);
-            PiEntity entity = new PiCounterCell(counterHandle.cellId(), data);
-            this.entities.add(entity);
+            PiCounterCellId cellId = counterHandle.cellId();
+            if (cellId.counterId().equals(FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER)) {
+                PiEntity entity = new PiCounterCell(
+                        counterHandle.cellId(),
+                        igCounters.get(cellId.index()).data());
+                this.entities.add(entity);
+            } else if (cellId.counterId().equals(FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER)) {
+                PiEntity entity = new PiCounterCell(
+                        counterHandle.cellId(),
+                        egCounters.get(cellId.index()).data());
+                this.entities.add(entity);
+            }
         }
         // Only handles counter cell so far
-
         return this;
     }
 

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockWriteRequest.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockWriteRequest.java
@@ -1,0 +1,125 @@
+// Copyright 2022-present Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.stratumproject.fabric.tna.behaviour.upf;
+
+import org.onosproject.net.DeviceId;
+import org.onosproject.net.pi.runtime.PiCounterCell;
+import org.onosproject.net.pi.runtime.PiCounterCellId;
+import org.onosproject.net.pi.runtime.PiEntity;
+import org.onosproject.net.pi.runtime.PiEntityType;
+import org.onosproject.net.pi.runtime.PiHandle;
+import org.onosproject.p4runtime.api.P4RuntimeWriteClient;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER;
+
+/**
+ * For faking writes to a p4runtime client. Currently, only used for testing
+ * UP4-specific counter writes, all other entities are accessed via other ONOS
+ * services.
+ */
+public class MockWriteRequest implements P4RuntimeWriteClient.WriteRequest {
+    private final List<PiEntity> toModifyEntities;
+    private final DeviceId deviceId;
+    private final Map<Long, PiCounterCell> igCounters;
+    private final Map<Long, PiCounterCell> egCounters;
+
+    public MockWriteRequest(DeviceId deviceId,
+                            Map<Long, PiCounterCell> igCounters,
+                            Map<Long, PiCounterCell> egCounters) {
+        this.toModifyEntities = new ArrayList<>();
+        this.deviceId = deviceId;
+        this.igCounters = igCounters;
+        this.egCounters = egCounters;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest withAtomicity(P4RuntimeWriteClient.Atomicity atomicity) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest insert(PiEntity entity) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest insert(Iterable<? extends PiEntity> entities) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest modify(PiEntity entity) {
+        toModifyEntities.add(entity);
+        return this;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest modify(Iterable<? extends PiEntity> entities) {
+        entities.forEach(toModifyEntities::add);
+        return this;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest delete(PiHandle handle) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest delete(Iterable<? extends PiHandle> handles) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest entity(PiEntity entity, P4RuntimeWriteClient.UpdateType updateType) {
+        return null;
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteRequest entities(Iterable<? extends PiEntity> entities,
+                                                      P4RuntimeWriteClient.UpdateType updateType) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<P4RuntimeWriteClient.WriteResponse> submit() {
+        modifyEntities();
+        return CompletableFuture.completedFuture(
+                new MockWriteResponse(toModifyEntities.size()));
+    }
+
+    @Override
+    public P4RuntimeWriteClient.WriteResponse submitSync() {
+        modifyEntities();
+        return new MockWriteResponse(toModifyEntities.size());
+    }
+
+    private void modifyEntities() {
+        // Only handles counter cell so far
+        toModifyEntities.forEach(
+                entity -> {
+                    if (entity.piEntityType().equals(PiEntityType.COUNTER_CELL)) {
+                        PiCounterCell counterCell = (PiCounterCell) entity;
+                        PiCounterCellId cellId = counterCell.cellId();
+                        if (cellId.counterId().equals(FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER)) {
+                            igCounters.computeIfPresent(cellId.index(), (k, v) -> counterCell);
+                        } else if (cellId.counterId().equals(FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER)) {
+                            egCounters.computeIfPresent(cellId.index(), (k, v) -> counterCell);
+                        }
+                    }
+                }
+        );
+    }
+
+    @Override
+    public Collection<P4RuntimeWriteClient.EntityUpdateRequest> pendingUpdates() {
+        return null;
+    }
+}

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockWriteResponse.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/MockWriteResponse.java
@@ -1,0 +1,61 @@
+// Copyright 2022-present Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.stratumproject.fabric.tna.behaviour.upf;
+
+import com.google.common.collect.Lists;
+import org.onosproject.p4runtime.api.P4RuntimeWriteClient;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+/**
+ * For faking writes to a p4runtime client. Currently, only used for testing
+ * UP4-specific counter writes, all other entities are accessed via other ONOS
+ * services.
+ */
+public class MockWriteResponse implements P4RuntimeWriteClient.WriteResponse {
+
+    int numEntities;
+
+    public MockWriteResponse(int numEntities) {
+        this.numEntities = numEntities;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return true;
+    }
+
+    @Override
+    public Collection<P4RuntimeWriteClient.EntityUpdateResponse> all() {
+        P4RuntimeWriteClient.EntityUpdateResponse mockPosResponse =
+                createMock(P4RuntimeWriteClient.EntityUpdateResponse.class);
+        expect(mockPosResponse.isSuccess())
+                .andReturn(true)
+                .anyTimes();
+        replay(mockPosResponse);
+        return LongStream.range(0, numEntities).mapToObj(i -> mockPosResponse).collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<P4RuntimeWriteClient.EntityUpdateResponse> success() {
+        return all();
+    }
+
+    @Override
+    public Collection<P4RuntimeWriteClient.EntityUpdateResponse> failed() {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public Collection<P4RuntimeWriteClient.EntityUpdateResponse> status(
+            P4RuntimeWriteClient.EntityUpdateStatus status) {
+        return null;
+    }
+}

--- a/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
+++ b/src/test/java/org/stratumproject/fabric/tna/behaviour/upf/TestUpfConstants.java
@@ -11,6 +11,7 @@ import org.onosproject.core.ApplicationId;
 import org.onosproject.core.DefaultApplicationId;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.behaviour.upf.UpfApplication;
+import org.onosproject.net.behaviour.upf.UpfCounter;
 import org.onosproject.net.behaviour.upf.UpfGtpTunnelPeer;
 import org.onosproject.net.behaviour.upf.UpfInterface;
 import org.onosproject.net.behaviour.upf.UpfMeter;
@@ -32,6 +33,9 @@ import org.onosproject.net.meter.MeterRequest;
 import org.onosproject.net.meter.MeterScope;
 import org.onosproject.net.pi.runtime.PiAction;
 import org.onosproject.net.pi.runtime.PiActionParam;
+import org.onosproject.net.pi.runtime.PiCounterCell;
+import org.onosproject.net.pi.runtime.PiCounterCellData;
+import org.onosproject.net.pi.runtime.PiCounterCellId;
 import org.onosproject.net.pi.runtime.PiMeterCellId;
 import org.stratumproject.fabric.tna.behaviour.P4InfoConstants;
 
@@ -42,6 +46,7 @@ import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.APP_METER_
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.CTR_ID;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_EG_TUNNEL_PEERS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_LOAD_TUNNEL_PARAMS;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_QOS_SLICE_TC_METER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APPLICATIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_APP_FWD;
@@ -60,6 +65,7 @@ import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_ING
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_SET_DOWNLINK_SESSION_BUF;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_SET_ROUTING_IPV4_DST;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_SET_UPLINK_SESSION;
+import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_UPLINK_DROP;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_UPLINK_SESSIONS;
 import static org.stratumproject.fabric.tna.behaviour.P4InfoConstants.FABRIC_INGRESS_UPF_UPLINK_TERMINATIONS;
@@ -121,8 +127,14 @@ public final class TestUpfConstants {
     public static final int PHYSICAL_MAX_SLICE_METERS = 1 << 6;
 
 
-    public static final long COUNTER_BYTES = 12;
-    public static final long COUNTER_PKTS = 15;
+    public static final long UL_IG_COUNTER_BYTES = 12;
+    public static final long UL_IG_COUNTER_PKTS = 13;
+    public static final long UL_EG_COUNTER_BYTES = 14;
+    public static final long UL_EG_COUNTER_PKTS = 15;
+    public static final long DL_IG_COUNTER_BYTES = 16;
+    public static final long DL_IG_COUNTER_PKTS = 17;
+    public static final long DL_EG_COUNTER_BYTES = 18;
+    public static final long DL_EG_COUNTER_PKTS = 19;
 
     public static final byte APP_FILTERING_ID = 10;
     public static final byte DEFAULT_APP_ID = 0;
@@ -253,6 +265,42 @@ public final class TestUpfConstants {
             .build();
 
     public static final UpfMeter SLICE_METER_RESET = UpfMeter.resetSlice(SLICE_METER_CELL_ID);
+
+    public static final UpfCounter UPLINK_COUNTER = UpfCounter.builder()
+            .withCellId(UPLINK_COUNTER_CELL_ID)
+            .setIngress(UL_IG_COUNTER_PKTS, UL_IG_COUNTER_BYTES)
+            .setEgress(UL_EG_COUNTER_PKTS, UL_EG_COUNTER_BYTES)
+            .build();
+
+    public static final UpfCounter UPLINK_IG_COUNTER = UpfCounter.builder()
+            .withCellId(UPLINK_COUNTER_CELL_ID)
+            .setIngress(UL_IG_COUNTER_PKTS, UL_IG_COUNTER_BYTES)
+            .isIngressCounter()
+            .build();
+
+    public static final UpfCounter UPLINK_EG_COUNTER = UpfCounter.builder()
+            .withCellId(UPLINK_COUNTER_CELL_ID)
+            .setEgress(UL_EG_COUNTER_PKTS, UL_EG_COUNTER_BYTES)
+            .isEgressCounter()
+            .build();
+
+    public static final UpfCounter DOWNLINK_COUNTER = UpfCounter.builder()
+            .withCellId(DOWNLINK_COUNTER_CELL_ID)
+            .setIngress(DL_IG_COUNTER_PKTS, DL_IG_COUNTER_BYTES)
+            .setEgress(DL_EG_COUNTER_PKTS, DL_EG_COUNTER_BYTES)
+            .build();
+
+    public static final UpfCounter DOWNLINK_IG_COUNTER = UpfCounter.builder()
+            .withCellId(DOWNLINK_COUNTER_CELL_ID)
+            .setIngress(DL_IG_COUNTER_PKTS, DL_IG_COUNTER_BYTES)
+            .isIngressCounter()
+            .build();
+
+    public static final UpfCounter DOWNLINK_EG_COUNTER = UpfCounter.builder()
+            .withCellId(DOWNLINK_COUNTER_CELL_ID)
+            .setEgress(DL_EG_COUNTER_PKTS, DL_EG_COUNTER_BYTES)
+            .isEgressCounter()
+            .build();
 
     public static final FlowRule FABRIC_INGRESS_GTP_TUNNEL_PEER = DefaultFlowRule.builder()
             .forDevice(DEVICE_ID).fromApp(APP_ID).makePermanent()
@@ -572,6 +620,26 @@ public final class TestUpfConstants {
             .withScope(MeterScope.of(FABRIC_INGRESS_QOS_SLICE_TC_METER.id()))
             .withUnit(BYTES_PER_SEC)
             .remove();
+
+    public static final PiCounterCell FABRIC_UPLINK_IG_COUNTER = new PiCounterCell(
+            PiCounterCellId.ofIndirect(FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER, UPLINK_COUNTER_CELL_ID),
+            new PiCounterCellData(UL_IG_COUNTER_PKTS, UL_IG_COUNTER_BYTES)
+    );
+
+    public static final PiCounterCell FABRIC_UPLINK_EG_COUNTER = new PiCounterCell(
+            PiCounterCellId.ofIndirect(FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER, UPLINK_COUNTER_CELL_ID),
+            new PiCounterCellData(UL_EG_COUNTER_PKTS, UL_EG_COUNTER_BYTES)
+    );
+
+    public static final PiCounterCell FABRIC_DOWNLINK_IG_COUNTER = new PiCounterCell(
+            PiCounterCellId.ofIndirect(FABRIC_INGRESS_UPF_TERMINATIONS_COUNTER, DOWNLINK_COUNTER_CELL_ID),
+            new PiCounterCellData(DL_IG_COUNTER_PKTS, DL_IG_COUNTER_BYTES)
+    );
+
+    public static final PiCounterCell FABRIC_DOWNLINK_EG_COUNTER = new PiCounterCell(
+            PiCounterCellId.ofIndirect(FABRIC_EGRESS_UPF_TERMINATIONS_COUNTER, DOWNLINK_COUNTER_CELL_ID),
+            new PiCounterCellData(DL_EG_COUNTER_PKTS, DL_EG_COUNTER_BYTES)
+    );
 
     /**
      * Hidden constructor for utility class.


### PR DESCRIPTION
Depends on: https://gerrit.onosproject.org/c/onos/+/25447

This PR consider only the read path. Code partially taken from:
- https://github.com/stratum/fabric-tna/pull/519
- https://github.com/stratum/fabric-tna/pull/517